### PR TITLE
Add interactive scoring and map controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SimRefinery Desk - Three.js prototype</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&family=Roboto:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="desktop">
+      <nav id="menu-bar" class="menu-bar" role="menubar">
+        <button type="button" class="menu-item" role="menuitem">File</button>
+        <button type="button" class="menu-item" role="menuitem">Options</button>
+        <button type="button" class="menu-item" role="menuitem">Refinery</button>
+        <button type="button" class="menu-item" role="menuitem">Windows</button>
+        <button type="button" class="menu-item" role="menuitem">Pause</button>
+        <div class="menu-spacer" aria-hidden="true"></div>
+        <span class="menu-title">SimRefinery Operator Console</span>
+      </nav>
+
+      <div class="windows">
+        <section class="window map-window" aria-label="SimRefinery refinery map window">
+          <header class="window-title">
+            <span>SimRefinery Map</span>
+            <span id="sim-clock" class="window-clock">Jan 01, 1992 03:00 AM</span>
+          </header>
+          <div class="window-body">
+            <div class="map-toolbar" role="toolbar" aria-label="Quick controls and shortcuts">
+              <button type="button" class="toolbar-button" data-preset="auto">AUTO CTL</button>
+              <button type="button" class="toolbar-button" data-preset="manual">MANUAL</button>
+              <button type="button" class="toolbar-button" data-preset="shutdown">SHUTDOWN</button>
+              <div class="toolbar-divider" role="separator"></div>
+              <button type="button" class="toolbar-button" data-unit-target="distillation">CDU</button>
+              <button type="button" class="toolbar-button" data-unit-target="reformer">REF</button>
+              <button type="button" class="toolbar-button" data-unit-target="fcc">FCC</button>
+              <button type="button" class="toolbar-button" data-unit-target="hydrocracker">HYD</button>
+              <button type="button" class="toolbar-button" data-unit-target="alkylation">ALKY</button>
+              <button type="button" class="toolbar-button" data-unit-target="sulfur">SULF</button>
+              <div class="toolbar-divider" role="separator"></div>
+              <button type="button" class="toolbar-button" data-scenario="steady">BASE</button>
+              <button type="button" class="toolbar-button" data-scenario="summerRush">SUMMER</button>
+              <button type="button" class="toolbar-button" data-scenario="winterDiesel">WINTER</button>
+              <button type="button" class="toolbar-button" data-scenario="quakeDrill">QUAKE</button>
+            </div>
+            <div id="map-viewport" aria-hidden="false">
+              <div id="scene-container" aria-label="Interactive refinery view"></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="window edit-window" aria-label="SimRefinery edit and monitoring window">
+          <header class="window-title">
+            <span>SimRefinery Edit</span>
+            <span id="mode-badge" class="mode-badge">AUTO</span>
+          </header>
+          <div class="window-body">
+            <div class="edit-grid">
+              <section id="hud" class="panel operations" aria-live="polite">
+                <h2>Operations Console</h2>
+                <div class="control-group">
+                  <label for="crude-input">Crude Intake <span id="crude-value"></span></label>
+                  <input type="range" id="crude-input" min="40" max="220" value="120" />
+                </div>
+                <div class="control-group">
+                  <label for="gasoline-focus">Product Focus <span id="focus-value"></span></label>
+                  <input type="range" id="gasoline-focus" min="0" max="100" value="50" />
+                  <p class="help-text">
+                    Shift production toward gasoline (right) or middle distillates (left).
+                  </p>
+                </div>
+                <div class="control-row">
+                  <div class="control-group compact">
+                    <label for="maintenance">Maintenance <span id="maintenance-value"></span></label>
+                    <input type="range" id="maintenance" min="0" max="100" value="65" />
+                  </div>
+                  <div class="control-group compact">
+                    <label for="safety">Safety Focus <span id="safety-value"></span></label>
+                    <input type="range" id="safety" min="0" max="100" value="45" />
+                  </div>
+                  <div class="control-group compact">
+                    <label for="env">Environmental Investment <span id="env-value"></span></label>
+                    <input type="range" id="env" min="0" max="100" value="35" />
+                  </div>
+                </div>
+                <div class="control-row buttons">
+                  <button id="toggle-sim" type="button">Pause</button>
+                  <button id="step-sim" type="button">Step</button>
+                  <button id="reset-sim" type="button">Reset</button>
+                </div>
+                <div class="scenario-group">
+                  <label for="scenario-select">Scenario</label>
+                  <select id="scenario-select" aria-describedby="scenario-description"></select>
+                  <p id="scenario-description" class="help-text"></p>
+                </div>
+              </section>
+
+              <section id="reports" class="panel metrics">
+                <h2>Production Dashboard</h2>
+                <div class="metric-grid">
+                  <div class="metric">
+                    <h3>Gasoline</h3>
+                    <span id="gasoline-output">0</span>
+                  </div>
+                  <div class="metric">
+                    <h3>Diesel</h3>
+                    <span id="diesel-output">0</span>
+                  </div>
+                  <div class="metric">
+                    <h3>Jet Fuel</h3>
+                    <span id="jet-output">0</span>
+                  </div>
+                  <div class="metric">
+                    <h3>LPG</h3>
+                    <span id="lpg-output">0</span>
+                  </div>
+                </div>
+                <div class="metric-wide">
+                  <h3>Profit / hr</h3>
+                  <span id="profit-output">$0</span>
+                </div>
+                <div class="metric-wide">
+                  <h3>Reliability</h3>
+                  <span id="reliability-output">100%</span>
+                </div>
+                <div class="metric-wide">
+                  <h3>Carbon Intensity</h3>
+                  <span id="carbon-output">0</span>
+                </div>
+                <div class="metric-wide scorecard">
+                  <div class="scorecard-header">
+                    <h3>Operations Grade</h3>
+                    <div class="scorecard-grade">
+                      <span id="score-grade">B</span>
+                      <small id="score-delta">—</small>
+                    </div>
+                  </div>
+                  <canvas id="score-trend" width="220" height="64" aria-hidden="true"></canvas>
+                  <p id="score-note">Plant stabilizing…</p>
+                </div>
+              </section>
+
+              <section id="unit-panel" class="panel unit-detail" aria-live="polite">
+                <h2>Unit Detail</h2>
+                <div class="panel-body" id="unit-details">
+                  <p>Select a processing unit to inspect its condition.</p>
+                </div>
+              </section>
+
+              <section id="notifications" class="panel log-panel">
+                <h2>Event Log</h2>
+                <div class="panel-body">
+                  <ul id="event-log"></ul>
+                </div>
+              </section>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <section id="footer" class="window about-window">
+        <header class="window-title">Operator Notes</header>
+        <div class="window-body">
+          <p>
+            This interactive homage reimagines the 1992 SimRefinery console with a three.js map and retro
+            controls. Adjust levers, explore process flow, and watch how refinery choices ripple across the
+            plant while dashboards grade your performance.
+          </p>
+          <ul class="notes-list">
+            <li>Click any process unit to inspect throughput, utilization, and incident history.</li>
+            <li>Shift-drag or use the right mouse button to pan the map; scroll the mouse wheel to zoom.</li>
+            <li>Monitor the hovering gauges and alerts—yellow indicates strain, red marks critical incidents.</li>
+            <li>The Operations Grade panel blends profit, reliability, and emissions into a running score.</li>
+          </ul>
+        </div>
+      </section>
+    </div>
+
+    <script type="module" src="./src/main.js"></script>
+  </body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,1280 @@
+import * as THREE from "https://unpkg.com/three@0.152.2/build/three.module.js";
+import { RefinerySimulation } from "./simulation.js";
+import { UIController } from "./ui.js";
+
+const mapViewport = document.getElementById("map-viewport");
+const sceneContainer = document.getElementById("scene-container");
+
+const renderer = new THREE.WebGLRenderer({ antialias: false, alpha: true });
+renderer.setPixelRatio(1);
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+sceneContainer.appendChild(renderer.domElement);
+renderer.domElement.classList.add("scene-canvas");
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x08101d);
+
+const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 400);
+const BASE_VIEW = 110;
+camera.position.set(120, 145, 120);
+const cameraTarget = new THREE.Vector3(0, 0, 0);
+camera.lookAt(cameraTarget);
+const cameraOffset = camera.position.clone().sub(cameraTarget);
+let viewHeight = BASE_VIEW;
+
+const ambient = new THREE.AmbientLight(0xffffff, 0.92);
+scene.add(ambient);
+const keyLight = new THREE.DirectionalLight(0xfff2c6, 0.45);
+keyLight.position.set(160, 220, 80);
+scene.add(keyLight);
+const fillLight = new THREE.DirectionalLight(0x88aaff, 0.28);
+fillLight.position.set(-140, 120, -160);
+scene.add(fillLight);
+
+const simulation = new RefinerySimulation();
+const ui = new UIController(simulation);
+if (typeof ui.setModeBadge === "function") {
+  ui.setModeBadge("AUTO");
+}
+
+const MAP_COLS = 16;
+const MAP_ROWS = 12;
+const TILE_SIZE = 6;
+const MAP_WIDTH = MAP_COLS * TILE_SIZE;
+const MAP_HEIGHT = MAP_ROWS * TILE_SIZE;
+const ORIGIN_X = -MAP_WIDTH / 2 + TILE_SIZE / 2;
+const ORIGIN_Z = -MAP_HEIGHT / 2 + TILE_SIZE / 2;
+
+const pointer = new THREE.Vector2();
+const raycaster = new THREE.Raycaster();
+const panStart = new THREE.Vector2();
+let isPanning = false;
+let activePanPointer = null;
+
+const clickableMeshes = [];
+const unitVisuals = new Map();
+const pipelineVisuals = new Map();
+const waterLayers = [];
+let dockVisual = null;
+let flareVisual = null;
+const alertTextures = {};
+const gaugeColors = {
+  good: new THREE.Color(0x6ae28a),
+  warn: new THREE.Color(0xf2d06b),
+  bad: new THREE.Color(0xff6b5a),
+};
+
+const unitConfigs = [
+  {
+    id: "distillation",
+    name: "Crude Distillation",
+    tileX: 6,
+    tileY: 3,
+    width: 3,
+    height: 4,
+    color: 0xbec9df,
+    accent: 0xf3cf73,
+    accentAlt: 0xe8933d,
+    style: "towers",
+  },
+  {
+    id: "reformer",
+    name: "Naphtha Reformer",
+    tileX: 3,
+    tileY: 6,
+    width: 2,
+    height: 3,
+    color: 0xd6aa80,
+    accent: 0x8c5a31,
+    accentAlt: 0xf2d5a4,
+    style: "rect",
+  },
+  {
+    id: "fcc",
+    name: "Catalytic Cracker",
+    tileX: 10,
+    tileY: 6,
+    width: 3,
+    height: 3,
+    color: 0xe2c568,
+    accent: 0x9a6a24,
+    accentAlt: 0xf6df9a,
+    style: "reactor",
+  },
+  {
+    id: "hydrocracker",
+    name: "Hydrocracker",
+    tileX: 3,
+    tileY: 2,
+    width: 2,
+    height: 3,
+    color: 0xb6ded0,
+    accent: 0x419a74,
+    accentAlt: 0xdaf0e8,
+    style: "towers",
+  },
+  {
+    id: "alkylation",
+    name: "Alkylation",
+    tileX: 11,
+    tileY: 2,
+    width: 2,
+    height: 3,
+    color: 0xd3b3f2,
+    accent: 0x845ec4,
+    accentAlt: 0xf3e1ff,
+    style: "rect",
+  },
+  {
+    id: "sulfur",
+    name: "Sulfur Recovery",
+    tileX: 7,
+    tileY: 9,
+    width: 2,
+    height: 2,
+    color: 0xe9edf1,
+    accent: 0x8c96a7,
+    accentAlt: 0xf7f9fb,
+    style: "support",
+  },
+];
+
+const pipelineConfigs = [
+  {
+    id: "toReformer",
+    metric: "toReformer",
+    capacity: 70,
+    color: 0x6fc2ff,
+    phase: 0,
+    path: [
+      { x: 7, y: 4.5 },
+      { x: 5, y: 4.5 },
+      { x: 5, y: 7 },
+      { x: 3.5, y: 7 },
+    ],
+  },
+  {
+    id: "toCracker",
+    metric: "toCracker",
+    capacity: 90,
+    color: 0xf7b25c,
+    phase: 1.3,
+    path: [
+      { x: 7, y: 4.5 },
+      { x: 9.5, y: 4.5 },
+      { x: 9.5, y: 7 },
+      { x: 11, y: 7 },
+    ],
+  },
+  {
+    id: "toHydrocracker",
+    metric: "toHydrocracker",
+    capacity: 70,
+    color: 0x8ee2c4,
+    phase: 2.2,
+    path: [
+      { x: 7, y: 4.5 },
+      { x: 4.5, y: 4.5 },
+      { x: 4.5, y: 3.5 },
+      { x: 3.5, y: 3.5 },
+    ],
+  },
+  {
+    id: "toAlkylation",
+    metric: "toAlkylation",
+    capacity: 45,
+    color: 0xc5a1ff,
+    phase: 2.9,
+    path: [
+      { x: 11, y: 7 },
+      { x: 12, y: 7 },
+      { x: 12, y: 3.5 },
+    ],
+  },
+  {
+    id: "toExport",
+    metric: "toExport",
+    capacity: 160,
+    color: 0x9ec8ff,
+    phase: 3.6,
+    path: [
+      { x: 7, y: 4.5 },
+      { x: 11, y: 4.5 },
+      { x: 11, y: 9.5 },
+      { x: 13.5, y: 9.5 },
+    ],
+  },
+];
+
+buildTerrain();
+buildUnits();
+buildPipelines();
+buildDecor();
+
+const PRESETS = {
+  auto: {
+    label: "AUTO",
+    crude: 120,
+    focus: 0.5,
+    maintenance: 0.65,
+    safety: 0.45,
+    environment: 0.35,
+    log: "Operator returned controls to automatic balancing.",
+  },
+  manual: {
+    label: "MANUAL",
+    crude: 180,
+    focus: 0.68,
+    maintenance: 0.45,
+    safety: 0.36,
+    environment: 0.22,
+    log: "Manual push: throughput prioritized for gasoline blending.",
+  },
+  shutdown: {
+    label: "SHUTDN",
+    crude: 60,
+    focus: 0.42,
+    maintenance: 0.82,
+    safety: 0.72,
+    environment: 0.55,
+    log: "Emergency shutdown drill initiated.",
+  },
+};
+
+let activePreset = "auto";
+
+const toolbarPresetButtons = document.querySelectorAll("[data-preset]");
+const toolbarUnitButtons = document.querySelectorAll("[data-unit-target]");
+const toolbarScenarioButtons = document.querySelectorAll("[data-scenario]");
+
+toolbarPresetButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const preset = button.dataset.preset;
+    applyPreset(preset);
+  });
+});
+
+toolbarUnitButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const target = button.dataset.unitTarget || null;
+    setSelectedUnit(target);
+    ui.selectUnit(target);
+  });
+});
+
+toolbarScenarioButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const scenario = button.dataset.scenario;
+    if (!scenario) return;
+    simulation.applyScenario(scenario);
+    ui.setScenario(scenario);
+    updateScenarioButtons(scenario);
+  });
+});
+
+const sliderInputs = document.querySelectorAll('#hud input[type="range"]');
+sliderInputs.forEach((input) => {
+  input.addEventListener("input", () => {
+    updatePresetButtons(null);
+    activePreset = null;
+    if (typeof ui.setModeBadge === "function") {
+      ui.setModeBadge("CUSTOM");
+    }
+  });
+});
+
+if (ui.elements?.scenario) {
+  ui.elements.scenario.addEventListener("change", (event) => {
+    updateScenarioButtons(event.target.value);
+  });
+}
+
+if (ui.elements?.reset) {
+  ui.elements.reset.addEventListener("click", () => {
+    setSelectedUnit(null);
+    ui.selectUnit(null);
+    updateUnitButtons(null);
+    applyPreset("auto", { silent: true });
+    updatePresetButtons("auto");
+    if (typeof ui.setModeBadge === "function") {
+      ui.setModeBadge("AUTO");
+    }
+    updateScenarioButtons(simulation.activeScenarioKey);
+  });
+}
+
+applyPreset("auto", { silent: true });
+updatePresetButtons("auto");
+updateScenarioButtons(simulation.activeScenarioKey);
+updateUnitButtons(null);
+ui.refreshControls();
+
+renderer.domElement.addEventListener("pointerdown", handlePointerDown);
+renderer.domElement.addEventListener("pointermove", handlePointerMove);
+renderer.domElement.addEventListener("pointerup", handlePointerUp);
+renderer.domElement.addEventListener("pointerleave", handlePointerUp);
+renderer.domElement.addEventListener("pointercancel", handlePointerUp);
+renderer.domElement.addEventListener("wheel", handleWheel, { passive: false });
+renderer.domElement.addEventListener("contextmenu", (event) => event.preventDefault());
+
+if ("ResizeObserver" in window) {
+  const resizeObserver = new ResizeObserver(() => resizeRenderer());
+  resizeObserver.observe(mapViewport);
+}
+window.addEventListener("resize", resizeRenderer);
+resizeRenderer();
+
+const clock = new THREE.Clock();
+let elapsed = 0;
+function animate() {
+  requestAnimationFrame(animate);
+  const delta = clock.getDelta();
+  elapsed += delta;
+
+  simulation.update(delta);
+  ui.update();
+
+  updateUnits(elapsed);
+  updatePipelines(simulation.getFlows(), elapsed);
+  updateEnvironment(elapsed);
+
+  renderer.render(scene, camera);
+}
+
+animate();
+
+function applyPreset(name, options = {}) {
+  const preset = PRESETS[name];
+  if (!preset) {
+    return;
+  }
+  simulation.setParam("crudeIntake", preset.crude);
+  simulation.setParam("productFocus", preset.focus);
+  simulation.setParam("maintenance", preset.maintenance);
+  simulation.setParam("safety", preset.safety);
+  simulation.setParam("environment", preset.environment);
+
+  ui.refreshControls();
+  updatePresetButtons(name);
+  activePreset = name;
+  if (typeof ui.setModeBadge === "function") {
+    ui.setModeBadge(preset.label);
+  }
+  if (!options.silent) {
+    simulation.pushLog("info", preset.log);
+  }
+}
+
+function updatePresetButtons(name) {
+  toolbarPresetButtons.forEach((button) => {
+    const isActive = button.dataset.preset === name;
+    button.classList.toggle("active", Boolean(name) && isActive);
+  });
+}
+
+function updateUnitButtons(unitId) {
+  toolbarUnitButtons.forEach((button) => {
+    button.classList.toggle("active", button.dataset.unitTarget === unitId);
+  });
+}
+
+function updateScenarioButtons(key) {
+  toolbarScenarioButtons.forEach((button) => {
+    button.classList.toggle("active", button.dataset.scenario === key);
+  });
+}
+
+function resizeRenderer() {
+  const rect = mapViewport.getBoundingClientRect();
+  const width = Math.max(320, rect.width);
+  const height = Math.max(240, rect.height);
+  renderer.setSize(width, height, false);
+  updateCamera(width / height);
+}
+
+function updateCamera(aspect) {
+  camera.left = -viewHeight * aspect;
+  camera.right = viewHeight * aspect;
+  camera.top = viewHeight;
+  camera.bottom = -viewHeight;
+  camera.updateProjectionMatrix();
+  camera.position.copy(cameraTarget).add(cameraOffset);
+  camera.lookAt(cameraTarget);
+}
+
+function buildTerrain() {
+  createGroundTiles();
+  createWaterArea(11, 0, 5, 6);
+  createWaterArea(12, 6, 4, 3);
+  createPavedStrip(0, 8.5, 16, 1.2, 0x343b3d, 0.12);
+  createPavedStrip(0, 10.5, 16, 1.2, 0x2c3234, 0.12);
+  createPavedStrip(5.5, 2, 5, 0.6, 0x474f52, 0.1);
+  createPavedStrip(5.5, 6.8, 5, 0.6, 0x474f52, 0.1);
+  createGridOverlay();
+}
+
+function createGroundTiles() {
+  const colors = [0x21302a, 0x1b2a24];
+  for (let y = 0; y < MAP_ROWS; y += 1) {
+    for (let x = 0; x < MAP_COLS; x += 1) {
+      const color = colors[(x + y) % 2];
+      const tile = new THREE.Mesh(
+        new THREE.PlaneGeometry(TILE_SIZE, TILE_SIZE),
+        new THREE.MeshBasicMaterial({ color })
+      );
+      tile.rotation.x = -Math.PI / 2;
+      const position = tileToWorld(x, y);
+      tile.position.set(position.x, 0, position.z);
+      scene.add(tile);
+    }
+  }
+}
+
+function createWaterArea(tileX, tileY, width, height) {
+  const geometry = new THREE.BoxGeometry(width * TILE_SIZE, 0.3, height * TILE_SIZE);
+  const material = new THREE.MeshPhongMaterial({
+    color: 0x1c3c62,
+    transparent: true,
+    opacity: 0.86,
+    shininess: 80,
+    specular: 0x396da0,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  const center = tileToWorld(tileX + (width - 1) / 2, tileY + (height - 1) / 2);
+  mesh.position.set(center.x, -0.16, center.z);
+  scene.add(mesh);
+  waterLayers.push({ mesh, material, baseColor: new THREE.Color(0x1c3c62) });
+}
+
+function createPavedStrip(tileX, tileY, width, height, color, elevation = 0.08) {
+  const geometry = new THREE.BoxGeometry(width * TILE_SIZE, elevation * 2, height * TILE_SIZE);
+  const material = new THREE.MeshLambertMaterial({ color, flatShading: true });
+  const mesh = new THREE.Mesh(geometry, material);
+  const center = tileToWorld(tileX + (width - 1) / 2, tileY + (height - 1) / 2);
+  mesh.position.set(center.x, elevation, center.z);
+  scene.add(mesh);
+}
+
+function createGridOverlay() {
+  const positions = [];
+  const startX = -MAP_WIDTH / 2;
+  const startZ = -MAP_HEIGHT / 2;
+  for (let x = 0; x <= MAP_COLS; x += 1) {
+    const worldX = startX + x * TILE_SIZE;
+    positions.push(worldX, 0.03, startZ, worldX, 0.03, startZ + MAP_HEIGHT);
+  }
+  for (let y = 0; y <= MAP_ROWS; y += 1) {
+    const worldZ = startZ + y * TILE_SIZE;
+    positions.push(startX, 0.03, worldZ, startX + MAP_WIDTH, 0.03, worldZ);
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
+  const material = new THREE.LineBasicMaterial({ color: 0x0c141d, transparent: true, opacity: 0.35 });
+  const grid = new THREE.LineSegments(geometry, material);
+  scene.add(grid);
+}
+
+function buildUnits() {
+  unitConfigs.forEach((config, index) => {
+    const visual = createUnitVisual(config, index * 0.6);
+    unitVisuals.set(config.id, visual);
+  });
+}
+
+function buildPipelines() {
+  pipelineConfigs.forEach((config) => {
+    const visual = createPipelineVisual(config);
+    pipelineVisuals.set(config.id, visual);
+  });
+}
+
+function buildDecor() {
+  createTankFarm();
+  dockVisual = createDock();
+  flareVisual = createFlare(tileToWorld(13.5, 1));
+  createLightTowers();
+}
+
+function createUnitVisual(config, phase = 0) {
+  const group = new THREE.Group();
+  const center = tileToWorld(
+    config.tileX + (config.width - 1) / 2,
+    config.tileY + (config.height - 1) / 2
+  );
+  group.position.set(center.x, 0, center.z);
+  group.userData.unitId = config.id;
+
+  const baseMaterial = new THREE.MeshStandardMaterial({
+    color: config.color,
+    roughness: 0.85,
+    metalness: 0.05,
+    flatShading: true,
+  });
+
+  const body = new THREE.Mesh(
+    new THREE.BoxGeometry(
+      config.width * TILE_SIZE - 2.2,
+      2.6,
+      config.height * TILE_SIZE - 2.2
+    ),
+    baseMaterial
+  );
+  body.position.y = 1.3;
+  body.userData.unitId = config.id;
+  group.add(body);
+  clickableMeshes.push(body);
+
+  const highlight = new THREE.Mesh(
+    new THREE.PlaneGeometry(config.width * TILE_SIZE + 3, config.height * TILE_SIZE + 3),
+    new THREE.MeshBasicMaterial({ color: 0xfff2c9, transparent: true, opacity: 0.18, depthWrite: false })
+  );
+  highlight.rotation.x = -Math.PI / 2;
+  highlight.position.y = 0.12;
+  group.add(highlight);
+
+  const accentMaterials = [];
+  if (config.style === "towers") {
+    for (let i = 0; i < 2; i += 1) {
+      const towerMaterial = new THREE.MeshStandardMaterial({
+        color: config.accent,
+        roughness: 0.6,
+        metalness: 0.2,
+        flatShading: true,
+      });
+      const radius = 1.4 + i * 0.2;
+      const tower = new THREE.Mesh(new THREE.CylinderGeometry(radius, radius, 5.4 + i, 12), towerMaterial);
+      tower.position.set((i === 0 ? -1 : 1) * TILE_SIZE * 0.6, 3.2 + i * 0.1, i === 0 ? 0 : TILE_SIZE * 0.7);
+      tower.rotation.y = Math.PI / 4;
+      tower.userData.unitId = config.id;
+      accentMaterials.push(towerMaterial);
+      group.add(tower);
+      clickableMeshes.push(tower);
+    }
+  } else if (config.style === "reactor") {
+    const plinthMaterial = new THREE.MeshStandardMaterial({
+      color: config.accentAlt,
+      roughness: 0.7,
+      metalness: 0.15,
+      flatShading: true,
+    });
+    const plinth = new THREE.Mesh(
+      new THREE.BoxGeometry(config.width * TILE_SIZE - 3, 1.2, config.height * TILE_SIZE - 3),
+      plinthMaterial
+    );
+    plinth.position.y = 0.6;
+    plinth.userData.unitId = config.id;
+    group.add(plinth);
+    clickableMeshes.push(plinth);
+    accentMaterials.push(plinthMaterial);
+
+    const reactorMaterial = new THREE.MeshStandardMaterial({
+      color: config.accent,
+      roughness: 0.5,
+      metalness: 0.25,
+      flatShading: true,
+    });
+    const reactor = new THREE.Mesh(new THREE.BoxGeometry(6, 3.6, 6), reactorMaterial);
+    reactor.position.set(0, 3, 0);
+    reactor.userData.unitId = config.id;
+    group.add(reactor);
+    clickableMeshes.push(reactor);
+    accentMaterials.push(reactorMaterial);
+
+    const stackMaterial = new THREE.MeshStandardMaterial({
+      color: config.accentAlt,
+      roughness: 0.4,
+      metalness: 0.3,
+      flatShading: true,
+    });
+    const stack = new THREE.Mesh(new THREE.CylinderGeometry(1.2, 1.2, 5, 10), stackMaterial);
+    stack.position.set(TILE_SIZE * 0.8, 4.2, -TILE_SIZE * 0.2);
+    stack.userData.unitId = config.id;
+    group.add(stack);
+    clickableMeshes.push(stack);
+    accentMaterials.push(stackMaterial);
+  } else if (config.style === "support") {
+    const frameMaterial = new THREE.MeshStandardMaterial({
+      color: config.accent,
+      roughness: 0.65,
+      metalness: 0.18,
+      flatShading: true,
+    });
+    const frame = new THREE.Mesh(new THREE.BoxGeometry(4, 2.4, 4), frameMaterial);
+    frame.position.set(0, 2.2, 0);
+    frame.userData.unitId = config.id;
+    group.add(frame);
+    clickableMeshes.push(frame);
+    accentMaterials.push(frameMaterial);
+
+    const ventMaterial = new THREE.MeshStandardMaterial({
+      color: config.accentAlt,
+      roughness: 0.45,
+      metalness: 0.15,
+      flatShading: true,
+    });
+    const vent = new THREE.Mesh(new THREE.CylinderGeometry(1.1, 1.2, 3.2, 10, 1, true), ventMaterial);
+    vent.rotation.x = Math.PI / 2;
+    vent.position.set(0, 3.4, TILE_SIZE * 0.4);
+    vent.userData.unitId = config.id;
+    group.add(vent);
+    clickableMeshes.push(vent);
+    accentMaterials.push(ventMaterial);
+  } else {
+    const roofMaterial = new THREE.MeshStandardMaterial({
+      color: config.accentAlt,
+      roughness: 0.6,
+      metalness: 0.2,
+      flatShading: true,
+    });
+    const roof = new THREE.Mesh(
+      new THREE.BoxGeometry(config.width * TILE_SIZE - 3, 1, config.height * TILE_SIZE - 3),
+      roofMaterial
+    );
+    roof.position.y = 2.4;
+    roof.userData.unitId = config.id;
+    group.add(roof);
+    clickableMeshes.push(roof);
+    accentMaterials.push(roofMaterial);
+
+    const towerMaterial = new THREE.MeshStandardMaterial({
+      color: config.accent,
+      roughness: 0.55,
+      metalness: 0.2,
+      flatShading: true,
+    });
+    const stack = new THREE.Mesh(new THREE.CylinderGeometry(0.9, 0.9, 4.4, 10), towerMaterial);
+    stack.position.set(TILE_SIZE * 0.4, 4, 0);
+    stack.userData.unitId = config.id;
+    group.add(stack);
+    clickableMeshes.push(stack);
+    accentMaterials.push(towerMaterial);
+  }
+
+  const lamp = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.5, 0.5, 0.4, 16),
+    new THREE.MeshBasicMaterial({ color: 0x7ad968, transparent: true, opacity: 0.9 })
+  );
+  lamp.position.set(-config.width * TILE_SIZE * 0.35, 2.5, -config.height * TILE_SIZE * 0.35);
+  group.add(lamp);
+
+  const label = createLabel(config.name, config.width * TILE_SIZE);
+  label.position.set(0, 3.8, config.height * TILE_SIZE * 0.5 + 2.5);
+  group.add(label);
+
+  const gaugeWidth = Math.max(config.width * TILE_SIZE - 2.4, 4.2);
+  const gauge = createGauge(gaugeWidth, 1);
+  gauge.group.position.set(0, 3.35, config.height * TILE_SIZE * 0.5 + 1.4);
+  group.add(gauge.group);
+
+  const alertSprite = new THREE.Sprite(
+    new THREE.SpriteMaterial({
+      map: getAlertTexture("warning"),
+      transparent: true,
+      opacity: 0,
+      depthWrite: false,
+    })
+  );
+  alertSprite.visible = false;
+  alertSprite.scale.set(5.2, 5.2, 1);
+  alertSprite.position.set(0, 4.6, 0);
+  alertSprite.userData.level = null;
+  group.add(alertSprite);
+
+  scene.add(group);
+
+  return {
+    id: config.id,
+    group,
+    baseMaterial,
+    accentMaterials,
+    baseColor: new THREE.Color(config.color),
+    accentColor: new THREE.Color(config.accent),
+    alertColor: new THREE.Color(config.accentAlt),
+    highlight,
+    label,
+    statusLamp: lamp,
+    gauge,
+    alertSprite,
+    phase,
+  };
+}
+
+function createPipelineVisual(config) {
+  const group = new THREE.Group();
+  const materials = [];
+  const thickness = 0.9;
+  const height = 0.5;
+
+  for (let i = 0; i < config.path.length - 1; i += 1) {
+    const start = tileToWorld(config.path[i].x, config.path[i].y);
+    const end = tileToWorld(config.path[i + 1].x, config.path[i + 1].y);
+    const dx = end.x - start.x;
+    const dz = end.z - start.z;
+    const length = Math.sqrt(dx * dx + dz * dz);
+    if (length <= 0) continue;
+    const isHorizontal = Math.abs(dx) >= Math.abs(dz);
+    const geometry = new THREE.BoxGeometry(
+      isHorizontal ? length : thickness,
+      height,
+      isHorizontal ? thickness : length
+    );
+    const material = new THREE.MeshStandardMaterial({
+      color: config.color,
+      roughness: 0.8,
+      metalness: 0.15,
+      transparent: true,
+      opacity: 0.32,
+      emissive: new THREE.Color(config.color).multiplyScalar(0.18),
+      flatShading: true,
+    });
+    const segment = new THREE.Mesh(geometry, material);
+    segment.position.set((start.x + end.x) / 2, height, (start.z + end.z) / 2);
+    group.add(segment);
+    materials.push(material);
+  }
+
+  scene.add(group);
+
+  return {
+    id: config.id,
+    config,
+    group,
+    materials,
+    baseColor: new THREE.Color(config.color),
+  };
+}
+
+function createTankFarm() {
+  const tankPositions = [
+    { x: 9.5, y: 9.3, radius: 2.2 },
+    { x: 10.5, y: 10.5, radius: 2.6 },
+    { x: 8.2, y: 10.2, radius: 2 },
+    { x: 11.8, y: 9.7, radius: 2.4 },
+  ];
+
+  tankPositions.forEach((entry, index) => {
+    const position = tileToWorld(entry.x, entry.y);
+    const shellMaterial = new THREE.MeshStandardMaterial({
+      color: 0xdde3ea,
+      roughness: 0.5,
+      metalness: 0.2,
+      flatShading: true,
+    });
+    const shell = new THREE.Mesh(
+      new THREE.CylinderGeometry(entry.radius, entry.radius, 2.8, 20),
+      shellMaterial
+    );
+    shell.position.set(position.x, 1.4, position.z);
+    scene.add(shell);
+
+    const roof = new THREE.Mesh(
+      new THREE.CylinderGeometry(entry.radius * 1.02, entry.radius * 1.02, 0.6, 20),
+      new THREE.MeshStandardMaterial({
+        color: 0xf6f8fb,
+        roughness: 0.45,
+        metalness: 0.1,
+        flatShading: true,
+      })
+    );
+    roof.position.set(position.x, 3.1, position.z);
+    scene.add(roof);
+
+    const ladder = new THREE.Mesh(
+      new THREE.BoxGeometry(entry.radius * 2.2, 0.15, 0.3),
+      new THREE.MeshBasicMaterial({ color: 0x6c7175 })
+    );
+    ladder.position.set(position.x, 3.05, position.z + entry.radius * 0.9);
+    ladder.rotation.y = index % 2 === 0 ? 0 : Math.PI / 6;
+    scene.add(ladder);
+  });
+}
+
+function createDock() {
+  const base = tileToWorld(13.8, 8.8);
+  const group = new THREE.Group();
+
+  const deck = new THREE.Mesh(
+    new THREE.BoxGeometry(12, 1.4, 6),
+    new THREE.MeshStandardMaterial({ color: 0x38424a, roughness: 0.65, metalness: 0.1, flatShading: true })
+  );
+  deck.position.set(base.x + 5, 0.7, base.z);
+  group.add(deck);
+
+  const ship = new THREE.Group();
+  const hull = new THREE.Mesh(
+    new THREE.BoxGeometry(10, 2.2, 4),
+    new THREE.MeshStandardMaterial({ color: 0x1c2733, roughness: 0.5, metalness: 0.15, flatShading: true })
+  );
+  hull.position.y = 1.1;
+  ship.add(hull);
+  const bridge = new THREE.Mesh(
+    new THREE.BoxGeometry(3.8, 1.5, 2.2),
+    new THREE.MeshStandardMaterial({ color: 0xf1f2f3, roughness: 0.4, metalness: 0.05, flatShading: true })
+  );
+  bridge.position.set(-2, 2.1, 0);
+  ship.add(bridge);
+  const stack = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.6, 0.6, 1.8, 12),
+    new THREE.MeshStandardMaterial({ color: 0xe26d44, roughness: 0.35, metalness: 0.25, flatShading: true })
+  );
+  stack.position.set(2, 2.6, 0);
+  ship.add(stack);
+  ship.position.set(base.x + 4.8, 0, base.z - 2.6);
+  group.add(ship);
+
+  scene.add(group);
+  return { group, ship };
+}
+
+function createFlare(position) {
+  const stack = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.6, 0.8, 6, 12),
+    new THREE.MeshStandardMaterial({ color: 0x555c63, roughness: 0.6, metalness: 0.25, flatShading: true })
+  );
+  stack.position.set(position.x, 3, position.z);
+  scene.add(stack);
+
+  const flame = new THREE.Mesh(
+    new THREE.ConeGeometry(1.6, 3.2, 14),
+    new THREE.MeshBasicMaterial({ color: 0xffc857, transparent: true, opacity: 0.55, depthWrite: false })
+  );
+  flame.position.set(position.x, 5.2, position.z);
+  scene.add(flame);
+
+  const light = new THREE.PointLight(0xff914d, 6, 32, 1.8);
+  light.position.set(position.x, 5.6, position.z);
+  scene.add(light);
+
+  return { stack, flame, light };
+}
+
+function createLightTowers() {
+  const positions = [tileToWorld(5, 1), tileToWorld(9, 2), tileToWorld(4, 8)];
+  positions.forEach((position) => {
+    const pole = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.2, 0.2, 5, 10),
+      new THREE.MeshStandardMaterial({ color: 0x59606a, roughness: 0.7, metalness: 0.2 })
+    );
+    pole.position.set(position.x, 2.5, position.z);
+    scene.add(pole);
+
+    const lamp = new THREE.Mesh(
+      new THREE.SphereGeometry(0.6, 10, 10),
+      new THREE.MeshBasicMaterial({ color: 0xfff0a6, transparent: true, opacity: 0.6 })
+    );
+    lamp.position.set(position.x, 5.4, position.z);
+    scene.add(lamp);
+  });
+}
+
+function createLabel(text, span) {
+  const width = 256;
+  const height = 96;
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext("2d");
+
+  context.fillStyle = "rgba(9, 16, 28, 0.8)";
+  context.fillRect(0, 0, width, height);
+  context.strokeStyle = "rgba(255, 255, 255, 0.3)";
+  context.lineWidth = 4;
+  context.strokeRect(8, 8, width - 16, height - 16);
+
+  context.fillStyle = "#dce9ff";
+  context.font = "48px Inconsolata";
+  context.textAlign = "center";
+  context.textBaseline = "middle";
+  context.fillText(text, width / 2, height / 2);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.anisotropy = renderer.capabilities.getMaxAnisotropy();
+  texture.minFilter = THREE.LinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.colorSpace = THREE.SRGBColorSpace;
+
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
+  const sprite = new THREE.Sprite(material);
+  const scaleX = Math.max(span * 0.6, 12);
+  sprite.scale.set(scaleX, 5, 1);
+  sprite.renderOrder = 3;
+  return sprite;
+}
+
+function createGauge(width, height) {
+  const group = new THREE.Group();
+  const background = new THREE.Mesh(
+    new THREE.PlaneGeometry(width, height),
+    new THREE.MeshBasicMaterial({
+      color: 0x0d1522,
+      transparent: true,
+      opacity: 0.78,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    })
+  );
+  group.add(background);
+
+  const fillMaterial = new THREE.MeshBasicMaterial({
+    color: gaugeColors.good.clone(),
+    transparent: true,
+    opacity: 0.92,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+  });
+  const fill = new THREE.Mesh(new THREE.PlaneGeometry(width, height), fillMaterial);
+  fill.position.z = 0.01;
+  fill.scale.x = 0.2;
+  fill.position.x = -width / 2 + (width * 0.2) / 2;
+  group.add(fill);
+
+  const frame = new THREE.LineSegments(
+    new THREE.EdgesGeometry(new THREE.PlaneGeometry(width, height)),
+    new THREE.LineBasicMaterial({ color: 0x1f2f3a, transparent: true, opacity: 0.65 })
+  );
+  frame.position.z = 0.02;
+  group.add(frame);
+
+  group.renderOrder = 4;
+
+  return { group, fill, background, width, height, frame };
+}
+
+function getAlertTexture(level) {
+  if (alertTextures[level]) {
+    return alertTextures[level];
+  }
+  const size = 256;
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+
+  ctx.clearRect(0, 0, size, size);
+  ctx.lineJoin = "round";
+  ctx.lineWidth = 18;
+
+  if (level === "danger") {
+    ctx.fillStyle = "#ff4f4f";
+    ctx.strokeStyle = "#ffe8e8";
+    ctx.beginPath();
+    ctx.moveTo(size / 2, 20);
+    ctx.lineTo(size - 24, size / 2);
+    ctx.lineTo(size / 2, size - 24);
+    ctx.lineTo(24, size / 2);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+  } else {
+    ctx.fillStyle = "#f3d477";
+    ctx.strokeStyle = "#4a3711";
+    ctx.beginPath();
+    ctx.moveTo(size / 2, 24);
+    ctx.lineTo(size - 28, size - 24);
+    ctx.lineTo(28, size - 24);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = level === "danger" ? "#ffffff" : "#1e1a0b";
+  ctx.font = "bold 132px Inconsolata";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("!", size / 2, size / 1.9);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.needsUpdate = true;
+  alertTextures[level] = texture;
+  return texture;
+}
+
+function updateGauge(gauge, utilization, integrity, isOnline, isSelected) {
+  const clampedUtilization = THREE.MathUtils.clamp(isOnline ? utilization : 0, 0, 1.2);
+  const fillWidth = Math.max(gauge.width * 0.08, Math.min(gauge.width, gauge.width * clampedUtilization));
+  gauge.fill.scale.x = fillWidth / gauge.width;
+  gauge.fill.position.x = -gauge.width / 2 + fillWidth / 2;
+
+  const color = gaugeColors.good.clone();
+  if (!isOnline) {
+    color.copy(gaugeColors.bad);
+  } else if (integrity < 0.4) {
+    color.copy(gaugeColors.bad);
+  } else if (integrity < 0.65) {
+    color.copy(gaugeColors.warn);
+  }
+  gauge.fill.material.color.copy(color);
+  gauge.fill.material.opacity = isOnline ? 0.92 : 0.6;
+
+  const baseOpacity = 0.68 + (isSelected ? 0.18 : 0);
+  gauge.background.material.opacity = baseOpacity;
+  gauge.background.material.color.set(isSelected ? 0x13243b : 0x0d1522);
+  if (gauge.frame?.material) {
+    gauge.frame.material.opacity = isSelected ? 0.85 : 0.6;
+    gauge.frame.material.color.set(isOnline ? 0x39546f : 0x5c1f1f);
+  }
+
+  const scale = isSelected ? 1.08 : 1;
+  gauge.group.scale.set(scale, scale, 1);
+}
+
+function updateAlertSprite(sprite, level, isSelected, time) {
+  if (!level) {
+    if (sprite.visible) {
+      sprite.material.opacity = THREE.MathUtils.lerp(sprite.material.opacity, 0, 0.18);
+      if (sprite.material.opacity < 0.05) {
+        sprite.visible = false;
+        sprite.userData.level = null;
+      }
+    }
+    return;
+  }
+
+  if (sprite.userData.level !== level) {
+    sprite.material.map = getAlertTexture(level);
+    sprite.material.needsUpdate = true;
+    sprite.userData.level = level;
+  }
+
+  const baseOpacity = level === "danger" ? 0.95 : 0.78;
+  sprite.visible = true;
+  sprite.material.opacity = THREE.MathUtils.lerp(sprite.material.opacity, baseOpacity, 0.18);
+  const pulse = Math.sin(time * (level === "danger" ? 6 : 4)) * 0.35;
+  const size = level === "danger" ? 6 + pulse : 5 + pulse * 0.6;
+  sprite.scale.set(size, size, 1);
+  sprite.position.y = 4.6 + (isSelected ? 0.4 : 0);
+}
+
+function billboard(object) {
+  if (!object) return;
+  object.quaternion.copy(camera.quaternion);
+}
+
+function tileToWorld(x, y) {
+  return new THREE.Vector3(ORIGIN_X + x * TILE_SIZE, 0, ORIGIN_Z + y * TILE_SIZE);
+}
+
+function handlePointerDown(event) {
+  const shouldPan =
+    event.button !== 0 ||
+    event.shiftKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey;
+
+  if (shouldPan) {
+    beginPan(event);
+    return;
+  }
+
+  selectUnitAtPointer(event);
+}
+
+function beginPan(event) {
+  isPanning = true;
+  activePanPointer = event.pointerId;
+  panStart.set(event.clientX, event.clientY);
+  try {
+    renderer.domElement.setPointerCapture(event.pointerId);
+  } catch (error) {
+    /* no-op */
+  }
+  mapViewport.classList.add("panning");
+}
+
+function handlePointerMove(event) {
+  if (!isPanning || event.pointerId !== activePanPointer) {
+    return;
+  }
+  const deltaX = event.clientX - panStart.x;
+  const deltaY = event.clientY - panStart.y;
+  panStart.set(event.clientX, event.clientY);
+  panCamera(deltaX, deltaY);
+}
+
+function handlePointerUp(event) {
+  if (isPanning && event.pointerId === activePanPointer) {
+    isPanning = false;
+    mapViewport.classList.remove("panning");
+    try {
+      renderer.domElement.releasePointerCapture(activePanPointer);
+    } catch (error) {
+      /* ignore */
+    }
+    activePanPointer = null;
+  }
+}
+
+function handleWheel(event) {
+  event.preventDefault();
+  const direction = Math.sign(event.deltaY);
+  const zoomFactor = direction > 0 ? 1.12 : 0.88;
+  viewHeight = THREE.MathUtils.clamp(viewHeight * zoomFactor, 55, 170);
+  const aspect = renderer.domElement.clientWidth / renderer.domElement.clientHeight;
+  updateCamera(aspect);
+}
+
+function panCamera(deltaX, deltaY) {
+  if (deltaX === 0 && deltaY === 0) {
+    return;
+  }
+  const element = renderer.domElement;
+  if (!element) return;
+
+  const worldPerPixel = (viewHeight * 2) / Math.max(1, element.clientHeight);
+  const forward = new THREE.Vector3();
+  camera.getWorldDirection(forward);
+  forward.y = 0;
+  forward.normalize();
+  const right = new THREE.Vector3().crossVectors(new THREE.Vector3(0, 1, 0), forward).normalize();
+  const up = new THREE.Vector3().crossVectors(forward, right).normalize();
+
+  const panOffset = new THREE.Vector3();
+  panOffset.addScaledVector(right, -deltaX * worldPerPixel * 0.9);
+  panOffset.addScaledVector(up, deltaY * worldPerPixel * 0.9);
+  panOffset.y = 0;
+
+  cameraTarget.add(panOffset);
+
+  const bounds = {
+    minX: -MAP_WIDTH / 2 + TILE_SIZE * 1.5,
+    maxX: MAP_WIDTH / 2 - TILE_SIZE * 1.5,
+    minZ: -MAP_HEIGHT / 2 + TILE_SIZE * 1.5,
+    maxZ: MAP_HEIGHT / 2 - TILE_SIZE * 1.5,
+  };
+
+  cameraTarget.x = THREE.MathUtils.clamp(cameraTarget.x, bounds.minX, bounds.maxX);
+  cameraTarget.z = THREE.MathUtils.clamp(cameraTarget.z, bounds.minZ, bounds.maxZ);
+
+  camera.position.copy(cameraTarget).add(cameraOffset);
+  camera.lookAt(cameraTarget);
+}
+
+function selectUnitAtPointer(event) {
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+
+  const intersections = raycaster.intersectObjects(clickableMeshes, true);
+  if (intersections.length > 0) {
+    const target = intersections[0].object.userData.unitId;
+    if (target) {
+      setSelectedUnit(target);
+      ui.selectUnit(target);
+      return;
+    }
+  }
+  setSelectedUnit(null);
+  ui.selectUnit(null);
+}
+
+let selectedUnitId = null;
+
+function setSelectedUnit(unitId) {
+  selectedUnitId = unitId;
+  updateUnitButtons(unitId);
+}
+
+function updateUnits(time) {
+  simulation.units.forEach((unit) => {
+    const visual = unitVisuals.get(unit.id);
+    if (!visual) return;
+    const utilization = unit.utilization || 0;
+    const integrity = THREE.MathUtils.clamp(unit.integrity, 0, 1);
+    const statusColor = unit.status === "online" ? visual.alertColor : new THREE.Color(0xd84545);
+    const mix = unit.status === "online" ? 1 - integrity : 0.85;
+    const targetColor = visual.baseColor.clone().lerp(statusColor, THREE.MathUtils.clamp(mix, 0, 1));
+    visual.baseMaterial.color.copy(targetColor);
+
+    visual.accentMaterials.forEach((material, index) => {
+      const pulse = (Math.sin(time * 2.2 + index) + 1) / 2;
+      const accentColor = visual.accentColor
+        .clone()
+        .lerp(statusColor, unit.status === "online" ? 0.25 : 0.65)
+        .lerp(visual.baseColor, 0.25 + pulse * 0.15);
+      material.color.copy(accentColor);
+    });
+
+    if (visual.statusLamp) {
+      const lampColor =
+        unit.status === "online"
+          ? integrity > 0.45
+            ? 0x74d77a
+            : 0xf2d06b
+          : 0xff6b5a;
+      visual.statusLamp.material.color.setHex(lampColor);
+      visual.statusLamp.material.opacity = 0.7 + utilization * 0.3;
+    }
+
+    if (visual.highlight) {
+      const baseOpacity = unit.status === "online" ? 0.2 : 0.3;
+      const pulse = Math.abs(Math.sin(time * 2.6 + visual.phase)) * (0.25 + utilization * 0.35);
+      const selectedBoost = selectedUnitId === unit.id ? 0.35 : 0;
+      visual.highlight.material.opacity = baseOpacity + pulse + selectedBoost;
+      visual.highlight.material.color.setHex(selectedUnitId === unit.id ? 0xfff6a5 : 0xfff2cc);
+    }
+
+    if (visual.label) {
+      visual.label.material.opacity = 0.65 + utilization * 0.3;
+    }
+
+    if (visual.gauge) {
+      updateGauge(visual.gauge, utilization, integrity, unit.status === "online", selectedUnitId === unit.id);
+      billboard(visual.gauge.group);
+    }
+
+    if (visual.alertSprite) {
+      updateAlertSprite(visual.alertSprite, unit.alert, selectedUnitId === unit.id, time);
+    }
+
+    visual.group.position.y = selectedUnitId === unit.id ? 0.22 : 0;
+  });
+}
+
+function updatePipelines(flows, time) {
+  pipelineVisuals.forEach((visual) => {
+    const flow = flows[visual.config.metric] || 0;
+    const normalized = visual.config.capacity
+      ? THREE.MathUtils.clamp(flow / visual.config.capacity, 0, 1.4)
+      : 0;
+    const pulse = Math.max(0, Math.sin(time * 3 + visual.config.phase));
+    visual.materials.forEach((material) => {
+      material.opacity = 0.18 + normalized * 0.5 + pulse * 0.12;
+      const emissive = visual.baseColor.clone().multiplyScalar(0.25 + normalized * 1.4 + pulse * 0.4);
+      material.emissive.copy(emissive);
+      material.color.copy(visual.baseColor.clone().lerp(new THREE.Color(0xffffff), normalized * 0.2));
+    });
+  });
+}
+
+function updateEnvironment(time) {
+  waterLayers.forEach((layer, index) => {
+    const wave = Math.sin(time * 1.1 + index * 0.6) * 0.12;
+    layer.mesh.position.y = -0.16 + wave * 0.4;
+    const hueShift = 0.04 * Math.sin(time * 0.5 + index);
+    const color = layer.baseColor.clone();
+    const hsl = { h: 0, s: 0, l: 0 };
+    color.getHSL(hsl);
+    hsl.l = THREE.MathUtils.clamp(hsl.l + hueShift * 0.08, 0, 1);
+    layer.material.color.setHSL(hsl.h, hsl.s, hsl.l);
+    layer.material.opacity = 0.82 + 0.05 * Math.sin(time * 0.9 + index);
+  });
+
+  if (dockVisual) {
+    dockVisual.ship.position.y = Math.sin(time * 1.1) * 0.4;
+    dockVisual.ship.rotation.z = Math.sin(time * 0.9) * 0.05;
+  }
+
+  if (flareVisual) {
+    const metrics = simulation.getMetrics();
+    const flareLevel = THREE.MathUtils.clamp(metrics.flareLevel, 0, 1.3);
+    const flicker = 0.2 + Math.abs(Math.sin(time * 9.2)) * 0.35;
+    flareVisual.flame.scale.set(1 + flareLevel * 0.45, 1 + flareLevel * 1.6 + flicker, 1);
+    flareVisual.flame.material.opacity = 0.35 + flareLevel * 0.4 + flicker * 0.2;
+    flareVisual.light.intensity = 3 + flareLevel * 8;
+    flareVisual.light.distance = 22 + flareLevel * 26;
+  }
+}
+

--- a/src/simulation.js
+++ b/src/simulation.js
@@ -1,0 +1,781 @@
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const HOURS_PER_DAY = 24;
+
+export class RefinerySimulation {
+  constructor() {
+    this.timeMinutes = 0;
+    this.tickInterval = 1; // simulated minute per tick
+    this.speed = 35; // simulated minutes per real second
+    this._accumulator = 0;
+    this.running = true;
+    this.stepOnce = false;
+
+    this.params = {
+      crudeIntake: 120, // kbpd
+      productFocus: 0.5, // 0 diesel, 1 gasoline
+      maintenance: 0.65,
+      safety: 0.45,
+      environment: 0.35,
+    };
+
+    this.scenarios = this._createScenarios();
+    this.activeScenarioKey = "steady";
+    this.activeScenario = this.scenarios[this.activeScenarioKey];
+
+    this.units = this._createUnits();
+    this.unitMap = Object.fromEntries(this.units.map((unit) => [unit.id, unit]));
+
+    this.metrics = {
+      gasoline: 0,
+      diesel: 0,
+      jet: 0,
+      lpg: 0,
+      profitPerHour: 0,
+      reliability: 1,
+      carbon: 0,
+      waste: 0,
+      flareLevel: 0,
+      incidents: 0,
+      score: 0,
+      grade: "B",
+      scoreNote: "Plant stabilizing…",
+      scoreDelta: 0,
+    };
+
+    this.flows = {
+      toReformer: 0,
+      toCracker: 0,
+      toHydrocracker: 0,
+      toAlkylation: 0,
+      toExport: 0,
+    };
+
+    this.performanceHistory = [];
+
+    this.logs = [];
+    this.pushLog(
+      "info",
+      "Simulation initialized. Adjust the sliders to explore the refinery."
+    );
+  }
+
+  _createScenarios() {
+    return {
+      steady: {
+        key: "steady",
+        name: "Steady Operations",
+        description: "Balanced demand and average Bay Area crude quality.",
+        crudeMultiplier: 1,
+        qualityShift: 0,
+        priceModifier: 1,
+        gasolineBias: 0,
+        dieselBias: 0,
+        jetBias: 0,
+        riskMultiplier: 1,
+        maintenancePenalty: 0,
+        environmentPressure: 0.2,
+      },
+      summerRush: {
+        key: "summerRush",
+        name: "Summer Driving Rush",
+        description:
+          "Gasoline demand surges with tourist traffic. Lighter crudes are available but the plant runs hot.",
+        crudeMultiplier: 1.05,
+        qualityShift: -0.05,
+        priceModifier: 1.08,
+        gasolineBias: 0.24,
+        dieselBias: -0.12,
+        jetBias: -0.05,
+        riskMultiplier: 1.12,
+        maintenancePenalty: 0.05,
+        environmentPressure: 0.1,
+      },
+      winterDiesel: {
+        key: "winterDiesel",
+        name: "Winter Heating Demand",
+        description:
+          "Heating oil and diesel spike while heavy, sour crude dominates supply.",
+        crudeMultiplier: 0.95,
+        qualityShift: 0.08,
+        priceModifier: 1.02,
+        gasolineBias: -0.1,
+        dieselBias: 0.28,
+        jetBias: -0.04,
+        riskMultiplier: 1.2,
+        maintenancePenalty: 0.12,
+        environmentPressure: 0.28,
+      },
+      exportPush: {
+        key: "exportPush",
+        name: "Pacific Jet Fuel Push",
+        description:
+          "Airlines pre-buy jet fuel for Pacific routes. Margins improve for kerosene and hydrogen-hungry units.",
+        crudeMultiplier: 1,
+        qualityShift: -0.02,
+        priceModifier: 1.06,
+        gasolineBias: -0.04,
+        dieselBias: -0.08,
+        jetBias: 0.32,
+        riskMultiplier: 1.15,
+        maintenancePenalty: 0.08,
+        environmentPressure: 0.18,
+      },
+      maintenanceCrunch: {
+        key: "maintenanceCrunch",
+        name: "Deferred Maintenance",
+        description:
+          "Budget cuts delayed turnarounds. Equipment is fragile and utilities are strained.",
+        crudeMultiplier: 0.9,
+        qualityShift: 0.05,
+        priceModifier: 0.97,
+        gasolineBias: 0,
+        dieselBias: 0.05,
+        jetBias: 0,
+        riskMultiplier: 1.45,
+        maintenancePenalty: 0.3,
+        environmentPressure: 0.35,
+      },
+      quakeDrill: {
+        key: "quakeDrill",
+        name: "Earthquake Drill",
+        description:
+          "A simulated quake tests emergency response. Utilities cut, shipments disrupted, and accidents spike.",
+        crudeMultiplier: 0.82,
+        qualityShift: 0.12,
+        priceModifier: 1.11,
+        gasolineBias: -0.06,
+        dieselBias: 0.12,
+        jetBias: 0,
+        riskMultiplier: 1.85,
+        maintenancePenalty: 0.42,
+        environmentPressure: 0.42,
+      },
+    };
+  }
+
+  _createUnits() {
+    return [
+      this._unit("distillation", "Crude Distillation Unit", 180, "core"),
+      this._unit("reformer", "Naphtha Reformer", 60, "naphtha"),
+      this._unit("fcc", "Catalytic Cracker", 85, "conversion"),
+      this._unit("hydrocracker", "Hydrocracker", 65, "conversion"),
+      this._unit("alkylation", "Alkylation", 45, "finishing"),
+      this._unit("sulfur", "Sulfur Recovery", 35, "support"),
+    ];
+  }
+
+  _unit(id, name, capacity, category) {
+    return {
+      id,
+      name,
+      capacity,
+      category,
+      throughput: 0,
+      utilization: 0,
+      integrity: 1,
+      downtime: 0,
+      status: "online",
+      incidents: 0,
+      alert: null,
+      alertTimer: 0,
+    };
+  }
+
+  setParam(key, value) {
+    if (key in this.params) {
+      this.params[key] = value;
+    }
+  }
+
+  applyScenario(key) {
+    if (this.scenarios[key]) {
+      this.activeScenarioKey = key;
+      this.activeScenario = this.scenarios[key];
+      this.pushLog(
+        "info",
+        `${this.activeScenario.name} scenario engaged. ${this.activeScenario.description}`
+      );
+    }
+  }
+
+  toggleRunning() {
+    this.running = !this.running;
+    return this.running;
+  }
+
+  requestStep() {
+    if (!this.running) {
+      this.stepOnce = true;
+    }
+  }
+
+  reset() {
+    this.timeMinutes = 0;
+    this._accumulator = 0;
+    this.running = true;
+    this.stepOnce = false;
+    this.metrics = {
+      gasoline: 0,
+      diesel: 0,
+      jet: 0,
+      lpg: 0,
+      profitPerHour: 0,
+      reliability: 1,
+      carbon: 0,
+      waste: 0,
+      flareLevel: 0,
+      incidents: 0,
+      score: 0,
+      grade: "B",
+      scoreNote: "Plant stabilizing…",
+      scoreDelta: 0,
+    };
+    this.flows = {
+      toReformer: 0,
+      toCracker: 0,
+      toHydrocracker: 0,
+      toAlkylation: 0,
+      toExport: 0,
+    };
+    this.units.forEach((unit) => {
+      unit.throughput = 0;
+      unit.utilization = 0;
+      unit.integrity = 1;
+      unit.downtime = 0;
+      unit.status = "online";
+      unit.incidents = 0;
+      unit.alert = null;
+      unit.alertTimer = 0;
+    });
+    this.performanceHistory = [];
+    this.logs = [];
+    this.pushLog(
+      "info",
+      "Simulation reset. Systems stabilized at baseline steady-state."
+    );
+  }
+
+  pushLog(level, message, meta = {}) {
+    const timestamp = this._formatTime();
+    this.logs.push({ level, message, timestamp, ...meta });
+    if (this.logs.length > 80) {
+      this.logs.splice(0, this.logs.length - 80);
+    }
+  }
+
+  getLogs() {
+    return [...this.logs].reverse();
+  }
+
+  getScenarioList() {
+    return Object.values(this.scenarios);
+  }
+
+  update(deltaSeconds) {
+    if (!this.running && !this.stepOnce) {
+      return;
+    }
+
+    this._accumulator += deltaSeconds * this.speed;
+
+    while (this._accumulator >= this.tickInterval) {
+      this._accumulator -= this.tickInterval;
+      this._advanceTick(this.tickInterval);
+
+      if (this.stepOnce) {
+        this.stepOnce = false;
+        this.running = false;
+        break;
+      }
+
+      if (!this.running) {
+        break;
+      }
+    }
+  }
+
+  _advanceTick(deltaMinutes) {
+    this.timeMinutes += deltaMinutes;
+    const hours = deltaMinutes / 60;
+
+    const scenario = this.activeScenario;
+    const crudeSetting = this.params.crudeIntake;
+    const crudeAvailable = crudeSetting * scenario.crudeMultiplier;
+
+    const distillation = this.unitMap.distillation;
+    const distOnline = this._unitIsAvailable(distillation);
+    const distCapacity = distOnline ? distillation.capacity : 0;
+    const crudeThroughput = Math.min(crudeAvailable, distCapacity);
+    distillation.throughput = crudeThroughput;
+    distillation.utilization = distCapacity
+      ? crudeThroughput / distCapacity
+      : 0;
+
+    const focus = clamp(this.params.productFocus, 0, 1);
+    const centered = focus - 0.5;
+
+    let gasShare = clamp(0.05 + centered * 0.05, 0.02, 0.12);
+    let naphthaShare = clamp(0.32 + centered * 0.22, 0.22, 0.5);
+    let keroseneShare = 0.11 + scenario.jetBias * 0.05;
+    let dieselShare = clamp(0.28 - centered * 0.16 + scenario.dieselBias * 0.06, 0.18, 0.38);
+    let heavyShare = clamp(0.19 - centered * 0.08, 0.12, 0.28);
+
+    let residShare = Math.max(
+      0.06,
+      1 - (gasShare + naphthaShare + keroseneShare + dieselShare + heavyShare)
+    );
+
+    const qualityShift = scenario.qualityShift;
+    if (qualityShift !== 0) {
+      const heavyAdjust = 1 + qualityShift;
+      naphthaShare *= 1 - 0.35 * qualityShift;
+      dieselShare *= 1 - 0.18 * qualityShift;
+      heavyShare *= heavyAdjust;
+      residShare *= heavyAdjust * 1.2;
+    }
+
+    const totalShares =
+      gasShare + naphthaShare + keroseneShare + dieselShare + heavyShare + residShare;
+    gasShare /= totalShares;
+    naphthaShare /= totalShares;
+    keroseneShare /= totalShares;
+    dieselShare /= totalShares;
+    heavyShare /= totalShares;
+    residShare /= totalShares;
+
+    const distGas = crudeThroughput * gasShare;
+    let naphthaPool = crudeThroughput * naphthaShare;
+    let kerosenePool = crudeThroughput * keroseneShare;
+    let dieselPool = crudeThroughput * dieselShare;
+    let heavyPool = crudeThroughput * heavyShare;
+    let residPool = crudeThroughput * residShare;
+
+    const result = {
+      gasoline: 0,
+      diesel: 0,
+      jet: 0,
+      lpg: 0,
+      hydrogen: 0,
+      waste: crudeThroughput * 0.01,
+      sulfur: 0,
+    };
+
+    let flare = 0;
+    const demandGasolineBias = scenario.gasolineBias;
+    const demandJetBias = scenario.jetBias;
+
+    const reformer = this.unitMap.reformer;
+    const reformerOnline = this._unitIsAvailable(reformer);
+    const reformerCapacity = reformerOnline ? reformer.capacity : 0;
+    const reformFeed = Math.min(naphthaPool, reformerCapacity);
+    naphthaPool -= reformFeed;
+    reformer.throughput = reformFeed;
+    reformer.utilization = reformerCapacity ? reformFeed / reformerCapacity : 0;
+
+    const reformate = reformFeed * 0.92;
+    const reformHydrogen = reformFeed * 0.05;
+    const reformLoss = reformFeed * 0.03;
+    result.gasoline += reformate;
+    result.hydrogen += reformHydrogen;
+    result.waste += reformLoss;
+
+    const fcc = this.unitMap.fcc;
+    const fccOnline = this._unitIsAvailable(fcc);
+    const fccCapacity = fccOnline ? fcc.capacity : 0;
+    const heavyAvailableForFcc = heavyPool + residPool * 0.6;
+    const fccFeed = Math.min(heavyAvailableForFcc, fccCapacity);
+    const heavyUsedByFcc = Math.min(heavyPool, fccFeed * 0.7);
+    heavyPool -= heavyUsedByFcc;
+    const residUsedByFcc = Math.min(residPool, fccFeed - heavyUsedByFcc);
+    residPool -= residUsedByFcc;
+
+    fcc.throughput = fccFeed;
+    fcc.utilization = fccCapacity ? fccFeed / fccCapacity : 0;
+
+    const fccGasoline = fccFeed * 0.54;
+    const fccDiesel = fccFeed * 0.12;
+    const fccLpg = fccFeed * 0.18;
+    const fccLoss = fccFeed * 0.08;
+    result.gasoline += fccGasoline;
+    dieselPool += fccDiesel;
+    let lpgPool = distGas + fccLpg;
+    result.waste += fccLoss;
+    flare += fccLoss * 0.5;
+
+    const hydrocracker = this.unitMap.hydrocracker;
+    const hydroOnline = this._unitIsAvailable(hydrocracker);
+    const hydroCapacity = hydroOnline ? hydrocracker.capacity : 0;
+    const hydroFeedAvailable = heavyPool + residPool + dieselPool * 0.25;
+    const hydroFeed = Math.min(hydroFeedAvailable, hydroCapacity);
+
+    const heavyUsedHydro = Math.min(heavyPool, hydroFeed * 0.55);
+    heavyPool -= heavyUsedHydro;
+    const residUsedHydro = Math.min(residPool, hydroFeed * 0.35);
+    residPool -= residUsedHydro;
+    const dieselUsedHydro = Math.min(dieselPool * 0.5, hydroFeed - heavyUsedHydro - residUsedHydro);
+    dieselPool -= dieselUsedHydro;
+
+    hydrocracker.throughput = hydroFeed;
+    hydrocracker.utilization = hydroCapacity ? hydroFeed / hydroCapacity : 0;
+
+    const hydroGasoline = hydroFeed * 0.42;
+    const hydroDiesel = hydroFeed * 0.3;
+    const hydroJet = hydroFeed * 0.2;
+    const hydroLoss = hydroFeed * 0.08;
+    result.gasoline += hydroGasoline;
+    dieselPool += hydroDiesel;
+    kerosenePool += hydroJet;
+    result.hydrogen += hydroFeed * 0.04;
+    result.waste += hydroLoss;
+
+    const alkylation = this.unitMap.alkylation;
+    const alkOnline = this._unitIsAvailable(alkylation);
+    const alkCapacity = alkOnline ? alkylation.capacity : 0;
+    const alkFeed = Math.min(lpgPool, alkCapacity);
+    lpgPool -= alkFeed;
+
+    alkylation.throughput = alkFeed;
+    alkylation.utilization = alkCapacity ? alkFeed / alkCapacity : 0;
+
+    const alkGasoline = alkFeed * 0.88;
+    const alkLoss = alkFeed * 0.06;
+    result.gasoline += alkGasoline;
+    result.lpg += lpgPool;
+    result.waste += alkLoss;
+
+    const sulfur = this.unitMap.sulfur;
+    const sulfurOnline = this._unitIsAvailable(sulfur);
+    const sulfurCapacity = sulfurOnline ? sulfur.capacity : 0;
+    const sulfurFeed = Math.min(residPool + heavyPool, sulfurCapacity);
+    const sulfurRemoved = sulfurFeed * (0.55 + this.params.environment * 0.4);
+    sulfur.throughput = sulfurFeed;
+    sulfur.utilization = sulfurCapacity ? sulfurFeed / sulfurCapacity : 0;
+    residPool -= sulfurFeed * 0.6;
+    heavyPool -= sulfurFeed * 0.4;
+    result.sulfur += sulfurRemoved;
+    result.waste += Math.max(0, sulfurFeed - sulfurRemoved);
+
+    result.gasoline += naphthaPool * 0.82;
+    result.diesel += dieselPool;
+    result.jet += kerosenePool * (1 + demandJetBias * 0.2);
+    result.waste += residPool + heavyPool;
+    result.lpg += Math.max(0, lpgPool);
+
+    const basePrices = {
+      gasoline: 96,
+      diesel: 88,
+      jet: 112,
+      lpg: 54,
+    };
+
+    const priceModifier = scenario.priceModifier;
+    const gasolinePrice = basePrices.gasoline * priceModifier * (1 + demandGasolineBias * 0.3);
+    const dieselPrice = basePrices.diesel * priceModifier * (1 + scenario.dieselBias * 0.25);
+    const jetPrice = basePrices.jet * priceModifier * (1 + demandJetBias * 0.35);
+    const lpgPrice = basePrices.lpg * priceModifier * (1 + demandGasolineBias * 0.1);
+
+    const crudeCostPerBbl = 53 * (1 + scenario.qualityShift * 0.8);
+    const maintenanceBudget =
+      2.2 * this.units.length * (0.5 + this.params.maintenance * 1.4 + scenario.maintenancePenalty);
+    const safetyBudget = 1.1 * this.params.safety * this.units.length;
+    const envBudget = 1.6 * this.params.environment * (1 + scenario.environmentPressure);
+
+    const productRevenue =
+      result.gasoline * gasolinePrice +
+      result.diesel * dieselPrice +
+      result.jet * jetPrice +
+      result.lpg * lpgPrice;
+    const crudeExpense = crudeThroughput * crudeCostPerBbl;
+    const operatingExpense = maintenanceBudget + safetyBudget + envBudget;
+
+    const incidentsRisk = this._updateReliability(
+      { distillation, reformer, fcc, hydrocracker, alkylation, sulfur },
+      { hours, scenario, flare }
+    );
+
+    const penalty = incidentsRisk.incidentPenalty;
+    const profitPerDay = productRevenue - crudeExpense - operatingExpense - penalty;
+    const profitPerHour = profitPerDay / HOURS_PER_DAY;
+
+    this.metrics.gasoline = this._round(result.gasoline);
+    this.metrics.diesel = this._round(result.diesel);
+    this.metrics.jet = this._round(result.jet);
+    this.metrics.lpg = this._round(result.lpg);
+    this.metrics.profitPerHour = profitPerHour;
+    this.metrics.waste = result.waste;
+    this.metrics.flareLevel = clamp((result.waste + flare * 1.4) / (crudeThroughput * 0.5 || 1), 0, 1);
+    this.metrics.incidents = incidentsRisk.incidents;
+    this.metrics.reliability = incidentsRisk.reliability;
+
+    const carbonBase =
+      result.waste * 3.5 +
+      result.diesel * 0.6 +
+      result.gasoline * 0.5 +
+      incidentsRisk.incidents * 2.8;
+    const envMitigation = 1 - clamp(this.params.environment * 0.55, 0, 0.6);
+    this.metrics.carbon = carbonBase * envMitigation;
+
+    this.flows.toReformer = reformFeed;
+    this.flows.toCracker = fccFeed;
+    this.flows.toHydrocracker = hydroFeed;
+    this.flows.toAlkylation = alkFeed;
+    this.flows.toExport = result.gasoline + result.diesel + result.jet;
+
+    this._updateScorecard({
+      profitPerHour,
+      crudeThroughput,
+      incidents: incidentsRisk.incidents,
+      reliability: this.metrics.reliability,
+      carbon: this.metrics.carbon,
+      gasoline: this.metrics.gasoline,
+      diesel: this.metrics.diesel,
+      jet: this.metrics.jet,
+    });
+
+    this._updateAlerts(deltaMinutes);
+  }
+
+  _unitIsAvailable(unit) {
+    if (!unit) return false;
+    if (unit.downtime > 0) {
+      unit.downtime = Math.max(0, unit.downtime - this.tickInterval);
+      if (unit.downtime === 0) {
+        unit.status = "online";
+        unit.integrity = 0.65 + Math.random() * 0.25;
+        unit.alert = null;
+        unit.alertTimer = 6;
+        this.pushLog("info", `${unit.name} cleared maintenance and is back online.`, {
+          unitId: unit.id,
+        });
+      }
+      return false;
+    }
+    return true;
+  }
+
+  _updateReliability(units, context) {
+    const maintenance = this.params.maintenance;
+    const safety = this.params.safety;
+    const scenario = context.scenario;
+
+    let incidents = 0;
+    let penalty = 0;
+    let integritySum = 0;
+
+    Object.values(units).forEach((unit) => {
+      if (!unit) return;
+      const utilization = unit.utilization || 0;
+      const baseWear = 0.004 * context.hours;
+      const stressWear = Math.max(0, utilization - 1) * 0.04 * context.hours;
+      const maintenanceFactor = 1.3 - maintenance * 0.9 - safety * 0.4;
+      const scenarioFactor = scenario.riskMultiplier;
+      const wear = (baseWear + stressWear) * maintenanceFactor * scenarioFactor;
+      unit.integrity = clamp(unit.integrity - wear, 0, 1);
+      integritySum += unit.integrity;
+
+      if (unit.integrity < 0.35 && unit.status === "online") {
+        const failurePressure = clamp(0.35 - unit.integrity, 0, 0.35);
+        const overload = Math.max(0, utilization - 0.95);
+        const riskIndex =
+          failurePressure * (0.9 + overload * 1.8) * (1.1 - maintenance) * scenario.riskMultiplier;
+        if (Math.random() < riskIndex) {
+          const severity = overload > 0.2 && safety < 0.45 ? "danger" : "warning";
+          const downtime = 30 + Math.random() * 90 + overload * 120;
+          unit.status = "offline";
+          unit.downtime = downtime;
+          unit.incidents += 1;
+          incidents += severity === "danger" ? 2 : 1;
+          penalty += severity === "danger" ? 320 : 140;
+          this.pushLog(
+            severity,
+            `${unit.name} tripped offline after a ${
+              severity === "danger" ? "critical" : "process"
+            } upset.`,
+            { unitId: unit.id }
+          );
+          if (severity === "danger") {
+            this.pushLog(
+              "danger",
+              `Emergency crews respond to pressure surge at ${unit.name}. Throughput curtailed.`,
+              { unitId: unit.id }
+            );
+          }
+          unit.alert = severity;
+          unit.alertTimer = Math.max(unit.alertTimer, severity === "danger" ? 180 : 90);
+        }
+      }
+    });
+
+    const reliability = clamp(
+      integritySum / Math.max(1, Object.keys(units).length),
+      0,
+      1
+    );
+    return {
+      reliability,
+      incidents,
+      incidentPenalty: penalty,
+    };
+  }
+
+  getMetrics() {
+    return { ...this.metrics };
+  }
+
+  getPerformanceHistory() {
+    return [...this.performanceHistory];
+  }
+
+  getTime() {
+    return this.timeMinutes;
+  }
+
+  getUnits() {
+    return this.units.map((unit) => ({ ...unit }));
+  }
+
+  getFlows() {
+    return { ...this.flows };
+  }
+
+  _formatTime() {
+    const totalMinutes = Math.floor(this.timeMinutes);
+    const days = Math.floor(totalMinutes / (60 * 24));
+    const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+    const minutes = totalMinutes % 60;
+    return `Day ${days + 1}, ${String(hours).padStart(2, "0")}:${String(minutes).padStart(
+      2,
+      "0"
+    )}`;
+  }
+
+  _round(value) {
+    return Math.round(value * 10) / 10;
+  }
+
+  _updateScorecard(context) {
+    const throughputTotal = context.gasoline + context.diesel + context.jet;
+    const throughputScore = clamp(throughputTotal / Math.max(1, context.crudeThroughput * 0.92), 0, 1);
+    const profitScore = clamp((context.profitPerHour + 140) / 320, 0, 1);
+    const reliabilityScore = clamp(context.reliability, 0, 1);
+    const carbonScore = clamp(1 - context.carbon / 140, 0, 1);
+    const incidentScore = clamp(1 - context.incidents * 0.18, 0, 1);
+
+    const composite = clamp(
+      throughputScore * 0.22 +
+        profitScore * 0.2 +
+        reliabilityScore * 0.26 +
+        carbonScore * 0.18 +
+        incidentScore * 0.14,
+      0,
+      1
+    );
+
+    const score = composite * 100;
+    const previous = this.performanceHistory.length
+      ? this.performanceHistory[this.performanceHistory.length - 1]
+      : score;
+    const delta = score - previous;
+
+    this.metrics.score = score;
+    this.metrics.grade = this._scoreToGrade(score);
+    this.metrics.scoreNote = this._scoreNarrative({
+      throughputScore,
+      profitScore,
+      reliabilityScore,
+      carbonScore,
+      incidentScore,
+    });
+    this.metrics.scoreDelta = delta;
+
+    this._recordPerformance(score);
+  }
+
+  _recordPerformance(score) {
+    this.performanceHistory.push(score);
+    if (this.performanceHistory.length > 240) {
+      this.performanceHistory.shift();
+    }
+  }
+
+  _scoreToGrade(score) {
+    if (score >= 92) return "A";
+    if (score >= 88) return "A-";
+    if (score >= 82) return "B+";
+    if (score >= 76) return "B";
+    if (score >= 70) return "B-";
+    if (score >= 64) return "C+";
+    if (score >= 58) return "C";
+    if (score >= 50) return "C-";
+    if (score >= 40) return "D";
+    return "F";
+  }
+
+  _scoreNarrative(scores) {
+    const issues = [];
+    const highlights = [];
+
+    if (scores.profitScore < 0.45) {
+      issues.push("Margins are tightening – rebalance crude or product slate.");
+    } else if (scores.profitScore > 0.75) {
+      highlights.push("Commercial returns are strong this shift.");
+    }
+
+    if (scores.reliabilityScore < 0.6) {
+      issues.push("Unit integrity is slipping; schedule maintenance time.");
+    } else if (scores.reliabilityScore > 0.85) {
+      highlights.push("Equipment health remains excellent.");
+    }
+
+    if (scores.carbonScore < 0.55) {
+      issues.push("Environmental controls are lagging – increase mitigation spend.");
+    } else if (scores.carbonScore > 0.8) {
+      highlights.push("Environmental intensity is well managed.");
+    }
+
+    if (scores.incidentScore < 0.75) {
+      issues.push("Recent upsets rattled crews; stabilize operations.");
+    }
+
+    if (scores.throughputScore < 0.55) {
+      issues.push("Throughput is under target; inspect front-end feed handling.");
+    } else if (scores.throughputScore > 0.8) {
+      highlights.push("Product output is beating plan.");
+    }
+
+    if (issues.length) {
+      return issues[0];
+    }
+    if (highlights.length) {
+      return highlights[0];
+    }
+    return "Plant stabilizing…";
+  }
+
+  _updateAlerts(deltaMinutes) {
+    this.units.forEach((unit) => {
+      if (unit.status === "offline") {
+        unit.alert = unit.alert === "danger" ? "danger" : "warning";
+        unit.alertTimer = Math.max(unit.alertTimer, 45);
+      } else if (unit.integrity < 0.45) {
+        unit.alert = unit.alert === "danger" ? "danger" : "warning";
+        unit.alertTimer = Math.max(unit.alertTimer, 30);
+      }
+
+      if (unit.alertTimer > 0) {
+        unit.alertTimer = Math.max(0, unit.alertTimer - deltaMinutes);
+        if (
+          unit.alertTimer === 0 &&
+          unit.status === "online" &&
+          unit.integrity >= 0.5 &&
+          unit.alert !== "danger"
+        ) {
+          unit.alert = null;
+        }
+      } else if (unit.alert && unit.status === "online" && unit.integrity >= 0.6) {
+        unit.alert = null;
+      }
+    });
+  }
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,420 @@
+export class UIController {
+  constructor(simulation) {
+    this.simulation = simulation;
+    this.selectedUnitId = null;
+    this.lastLogSignature = "";
+    this.modeFlashTimeout = null;
+
+    this.elements = {
+      crude: document.getElementById("crude-input"),
+      crudeValue: document.getElementById("crude-value"),
+      focus: document.getElementById("gasoline-focus"),
+      focusValue: document.getElementById("focus-value"),
+      maintenance: document.getElementById("maintenance"),
+      maintenanceValue: document.getElementById("maintenance-value"),
+      safety: document.getElementById("safety"),
+      safetyValue: document.getElementById("safety-value"),
+      environment: document.getElementById("env"),
+      environmentValue: document.getElementById("env-value"),
+      toggle: document.getElementById("toggle-sim"),
+      step: document.getElementById("step-sim"),
+      reset: document.getElementById("reset-sim"),
+      scenario: document.getElementById("scenario-select"),
+      scenarioDescription: document.getElementById("scenario-description"),
+      gasolineOutput: document.getElementById("gasoline-output"),
+      dieselOutput: document.getElementById("diesel-output"),
+      jetOutput: document.getElementById("jet-output"),
+      lpgOutput: document.getElementById("lpg-output"),
+      profitOutput: document.getElementById("profit-output"),
+      reliabilityOutput: document.getElementById("reliability-output"),
+      carbonOutput: document.getElementById("carbon-output"),
+      scoreGrade: document.getElementById("score-grade"),
+      scoreDelta: document.getElementById("score-delta"),
+      scoreNote: document.getElementById("score-note"),
+      scoreTrend: document.getElementById("score-trend"),
+      logList: document.getElementById("event-log"),
+      unitDetails: document.getElementById("unit-details"),
+      clock: document.getElementById("sim-clock"),
+      modeBadge: document.getElementById("mode-badge"),
+    };
+
+    this.profitFormatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    });
+
+    this._bindControls();
+    this._populateScenarios();
+    this._updateSliderLabels();
+    this._updateClock();
+
+    this.scoreTrendContext = null;
+    if (this.elements.scoreTrend) {
+      this.scoreTrendContext = this.elements.scoreTrend.getContext("2d");
+      if (this.scoreTrendContext) {
+        this.scoreTrendContext.imageSmoothingEnabled = false;
+      }
+    }
+    this.lastScoreSignature = "";
+  }
+
+  _bindControls() {
+    const { elements, simulation } = this;
+
+    elements.crude.addEventListener("input", (event) => {
+      const value = Number(event.target.value);
+      simulation.setParam("crudeIntake", value);
+      elements.crudeValue.textContent = `${value.toFixed(0)} kbpd`;
+    });
+
+    elements.focus.addEventListener("input", (event) => {
+      const value = Number(event.target.value) / 100;
+      simulation.setParam("productFocus", value);
+      elements.focusValue.textContent = value > 0.5 ? "Gasoline" : value < 0.5 ? "Diesel" : "Balanced";
+    });
+
+    elements.maintenance.addEventListener("input", (event) => {
+      const value = Number(event.target.value) / 100;
+      simulation.setParam("maintenance", value);
+      elements.maintenanceValue.textContent = `${Math.round(value * 100)}%`;
+    });
+
+    elements.safety.addEventListener("input", (event) => {
+      const value = Number(event.target.value) / 100;
+      simulation.setParam("safety", value);
+      elements.safetyValue.textContent = `${Math.round(value * 100)}%`;
+    });
+
+    elements.environment.addEventListener("input", (event) => {
+      const value = Number(event.target.value) / 100;
+      simulation.setParam("environment", value);
+      elements.environmentValue.textContent = `${Math.round(value * 100)}%`;
+    });
+
+    elements.toggle.addEventListener("click", () => {
+      const running = simulation.toggleRunning();
+      elements.toggle.textContent = running ? "Pause" : "Resume";
+    });
+
+    elements.step.addEventListener("click", () => {
+      simulation.requestStep();
+    });
+
+    elements.reset.addEventListener("click", () => {
+      simulation.reset();
+      this.selectedUnitId = null;
+      this._renderUnitDetails(null);
+      this._updateSliderLabels();
+    });
+
+    elements.scenario.addEventListener("change", (event) => {
+      simulation.applyScenario(event.target.value);
+      this._updateScenarioDescription();
+    });
+  }
+
+  _populateScenarios() {
+    const { elements, simulation } = this;
+    const scenarios = simulation.getScenarioList();
+    scenarios.forEach((scenario) => {
+      const option = document.createElement("option");
+      option.value = scenario.key;
+      option.textContent = scenario.name;
+      if (scenario.key === simulation.activeScenarioKey) {
+        option.selected = true;
+      }
+      elements.scenario.appendChild(option);
+    });
+    this._updateScenarioDescription();
+  }
+
+  _updateScenarioDescription() {
+    const { simulation, elements } = this;
+    const scenario = simulation.scenarios[elements.scenario.value];
+    if (scenario) {
+      elements.scenarioDescription.textContent = scenario.description;
+    }
+  }
+
+  _updateSliderLabels() {
+    const { elements, simulation } = this;
+    elements.crude.value = simulation.params.crudeIntake;
+    elements.focus.value = Math.round(simulation.params.productFocus * 100);
+    elements.maintenance.value = Math.round(simulation.params.maintenance * 100);
+    elements.safety.value = Math.round(simulation.params.safety * 100);
+    elements.environment.value = Math.round(simulation.params.environment * 100);
+
+    elements.crudeValue.textContent = `${simulation.params.crudeIntake.toFixed(0)} kbpd`;
+    elements.focusValue.textContent =
+      simulation.params.productFocus > 0.5
+        ? "Gasoline"
+        : simulation.params.productFocus < 0.5
+        ? "Diesel"
+        : "Balanced";
+    elements.maintenanceValue.textContent = `${Math.round(simulation.params.maintenance * 100)}%`;
+    elements.safetyValue.textContent = `${Math.round(simulation.params.safety * 100)}%`;
+    elements.environmentValue.textContent = `${Math.round(simulation.params.environment * 100)}%`;
+  }
+
+  setRunning(running) {
+    this.elements.toggle.textContent = running ? "Pause" : "Resume";
+  }
+
+  selectUnit(unitId) {
+    this.selectedUnitId = unitId;
+    const unit = this.simulation.getUnits().find((entry) => entry.id === unitId);
+    this._renderUnitDetails(unit || null);
+  }
+
+  _renderUnitDetails(unit) {
+    const { unitDetails } = this.elements;
+    unitDetails.innerHTML = "";
+
+    if (!unit) {
+      const paragraph = document.createElement("p");
+      paragraph.textContent = "Select a processing unit to inspect its condition.";
+      unitDetails.appendChild(paragraph);
+      return;
+    }
+
+    const title = document.createElement("h3");
+    title.textContent = unit.name;
+    unitDetails.appendChild(title);
+
+    const status = document.createElement("p");
+    status.textContent = unit.status === "online" ? "Online" : `Offline (${Math.ceil(unit.downtime)} min remaining)`;
+    status.classList.add("unit-status");
+    unitDetails.appendChild(status);
+
+    const list = document.createElement("div");
+    list.classList.add("unit-stats");
+
+    list.appendChild(this._statRow("Throughput", `${unit.throughput.toFixed(1)} kbpd`));
+    list.appendChild(this._statRow("Utilization", `${Math.round(unit.utilization * 100)}%`));
+    list.appendChild(this._statRow("Integrity", `${Math.round(unit.integrity * 100)}%`));
+    list.appendChild(this._statRow("Incidents", `${unit.incidents}`));
+
+    unitDetails.appendChild(list);
+  }
+
+  _statRow(label, value) {
+    const wrapper = document.createElement("div");
+    wrapper.classList.add("unit-stat");
+    const labelEl = document.createElement("span");
+    labelEl.textContent = label;
+    const valueEl = document.createElement("span");
+    valueEl.textContent = value;
+    wrapper.append(labelEl, valueEl);
+    return wrapper;
+  }
+
+  update() {
+    const metrics = this.simulation.getMetrics();
+    this._renderMetrics(metrics);
+    this._renderLogs();
+    this._updateClock();
+    if (this.selectedUnitId) {
+      const unit = this.simulation
+        .getUnits()
+        .find((entry) => entry.id === this.selectedUnitId);
+      this._renderUnitDetails(unit || null);
+    }
+  }
+
+  refreshControls() {
+    this._updateSliderLabels();
+  }
+
+  setScenario(key) {
+    if (!this.elements.scenario) return;
+    if (this.elements.scenario.value !== key) {
+      this.elements.scenario.value = key;
+    }
+    this._updateScenarioDescription();
+  }
+
+  setModeBadge(label) {
+    if (!this.elements.modeBadge) return;
+    this.elements.modeBadge.textContent = label;
+    this.elements.modeBadge.classList.remove("flash");
+    // restart animation
+    void this.elements.modeBadge.offsetWidth;
+    this.elements.modeBadge.classList.add("flash");
+    if (this.modeFlashTimeout) {
+      clearTimeout(this.modeFlashTimeout);
+    }
+    this.modeFlashTimeout = setTimeout(() => {
+      this.elements.modeBadge?.classList.remove("flash");
+    }, 450);
+  }
+
+  _renderMetrics(metrics) {
+    const formatBpd = (value) => `${value.toFixed(1)} kbpd`;
+    this.elements.gasolineOutput.textContent = formatBpd(metrics.gasoline);
+    this.elements.dieselOutput.textContent = formatBpd(metrics.diesel);
+    this.elements.jetOutput.textContent = formatBpd(metrics.jet);
+    this.elements.lpgOutput.textContent = formatBpd(metrics.lpg);
+
+    this.elements.profitOutput.textContent = `${this.profitFormatter.format(
+      Math.round(metrics.profitPerHour * 1000)
+    )} / hr`;
+
+    this.elements.reliabilityOutput.textContent = `${Math.round(metrics.reliability * 100)}%`;
+    this.elements.carbonOutput.textContent = `${metrics.carbon.toFixed(1)} tCO₂-eq`;
+
+    this._renderScorecard(metrics);
+  }
+
+  _renderLogs() {
+    const logs = this.simulation.getLogs();
+    const signature = logs.length ? `${logs[0].timestamp}-${logs[0].message}` : "";
+    if (signature === this.lastLogSignature) {
+      return;
+    }
+    this.lastLogSignature = signature;
+
+    this.elements.logList.innerHTML = "";
+    logs.slice(0, 30).forEach((entry) => {
+      const item = document.createElement("li");
+      if (entry.level !== "info") {
+        item.classList.add(entry.level);
+      }
+      item.textContent = `[${entry.timestamp}] ${entry.message}`;
+      this.elements.logList.appendChild(item);
+    });
+  }
+
+  _renderScorecard(metrics) {
+    const { scoreGrade, scoreDelta, scoreNote } = this.elements;
+    if (!scoreGrade) {
+      return;
+    }
+
+    const grade = metrics.grade ?? "—";
+    scoreGrade.textContent = grade;
+    if (typeof metrics.score === "number") {
+      scoreGrade.setAttribute("title", `Composite score ${metrics.score.toFixed(0)}`);
+    } else {
+      scoreGrade.removeAttribute("title");
+    }
+
+    if (scoreDelta) {
+      const delta = typeof metrics.scoreDelta === "number" ? metrics.scoreDelta : 0;
+      scoreDelta.classList.remove("positive", "negative");
+      if (Math.abs(delta) < 0.05) {
+        scoreDelta.textContent = "—";
+        scoreDelta.removeAttribute("title");
+      } else {
+        const positive = delta > 0;
+        scoreDelta.classList.add(positive ? "positive" : "negative");
+        const arrow = positive ? "▲" : "▼";
+        scoreDelta.textContent = `${arrow}${Math.abs(delta).toFixed(1)}`;
+        scoreDelta.setAttribute(
+          "title",
+          positive ? "Score trending upward" : "Score trending downward"
+        );
+      }
+    }
+
+    if (scoreNote) {
+      scoreNote.textContent = metrics.scoreNote || "Plant stabilizing…";
+    }
+
+    if (!this.scoreTrendContext) {
+      return;
+    }
+
+    const history = this.simulation.getPerformanceHistory();
+    const signature = history.length
+      ? `${history[history.length - 1].toFixed(2)}-${history.length}`
+      : "";
+    if (signature === this.lastScoreSignature) {
+      return;
+    }
+    this.lastScoreSignature = signature;
+    this._drawScoreTrend(history);
+  }
+
+  _drawScoreTrend(history) {
+    const ctx = this.scoreTrendContext;
+    if (!ctx) return;
+    const { width, height } = ctx.canvas;
+    ctx.clearRect(0, 0, width, height);
+    ctx.fillStyle = "rgba(6, 12, 20, 0.75)";
+    ctx.fillRect(0, 0, width, height);
+
+    if (!history.length) {
+      return;
+    }
+
+    const min = Math.min(50, ...history);
+    const max = Math.max(95, ...history);
+    const range = Math.max(1, max - min);
+    const gutterX = 4;
+    const gutterY = 4;
+
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.15)";
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 4]);
+    const targetNormalized = (75 - min) / range;
+    const targetY = height - gutterY - targetNormalized * (height - gutterY * 2);
+    const clampedTargetY = Math.min(height - gutterY, Math.max(gutterY, targetY));
+    ctx.beginPath();
+    ctx.moveTo(gutterX, clampedTargetY);
+    ctx.lineTo(width - gutterX, clampedTargetY);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    const points = history.map((value, index) => {
+      const x =
+        gutterX +
+        (index / Math.max(1, history.length - 1)) * (width - gutterX * 2);
+      const normalized = (value - min) / range;
+      const y = height - gutterY - normalized * (height - gutterY * 2);
+      return { x, y };
+    });
+
+    ctx.beginPath();
+    points.forEach((point, index) => {
+      if (index === 0) {
+        ctx.moveTo(point.x, point.y);
+      } else {
+        ctx.lineTo(point.x, point.y);
+      }
+    });
+    ctx.lineTo(points[points.length - 1].x, height - gutterY);
+    ctx.lineTo(points[0].x, height - gutterY);
+    ctx.closePath();
+    ctx.fillStyle = "rgba(88, 217, 149, 0.18)";
+    ctx.fill();
+
+    ctx.beginPath();
+    points.forEach((point, index) => {
+      if (index === 0) {
+        ctx.moveTo(point.x, point.y);
+      } else {
+        ctx.lineTo(point.x, point.y);
+      }
+    });
+    ctx.strokeStyle = "#58d995";
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+
+  _updateClock() {
+    if (!this.elements.clock) return;
+    const totalMinutes = Math.floor(this.simulation.getTime());
+    const base = Date.UTC(1992, 0, 1, 3, 0, 0);
+    const current = new Date(base + totalMinutes * 60_000);
+    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    const month = months[current.getUTCMonth()];
+    const day = String(current.getUTCDate()).padStart(2, "0");
+    const year = current.getUTCFullYear();
+    const hours = current.getUTCHours();
+    const minutes = String(current.getUTCMinutes()).padStart(2, "0");
+    const hour12 = ((hours + 11) % 12) + 1;
+    const ampm = hours >= 12 ? "PM" : "AM";
+    this.elements.clock.textContent = `${month} ${day}, ${year} ${String(hour12).padStart(2, "0")}:${minutes} ${ampm}`;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,603 @@
+:root {
+  color-scheme: only light;
+  --desktop-bg: radial-gradient(circle at 20% 20%, #1c2a3a 0%, #0a101a 65%);
+  --window-bg-light: #d7d7d7;
+  --window-bg-dark: #b6b6b6;
+  --window-border-light: #f5f5f5;
+  --window-border-dark: #707070;
+  --header-grad-top: #466a9f;
+  --header-grad-bottom: #244165;
+  --header-text: #f5f9ff;
+  --toolbar-bg: linear-gradient(#c8c8c8, #b4b4b4);
+  --toolbar-border: #5a5a5a;
+  --accent-blue: #1f4b7a;
+  --metric-bg: #f1f1f1;
+  --metric-border: #6b6b6b;
+  --log-info: #2d4f73;
+  --log-warning: #9f6d19;
+  --log-danger: #8a1e1e;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Roboto", sans-serif;
+  background: var(--desktop-bg);
+  color: #1b1b1b;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 18px;
+}
+
+#desktop {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.menu-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  background: linear-gradient(180deg, rgba(45, 72, 109, 0.94), rgba(15, 26, 42, 0.94));
+  border: 2px solid rgba(27, 45, 70, 0.7);
+  box-shadow: inset 0 1px 0 rgba(173, 204, 255, 0.3), inset 0 -1px 0 rgba(8, 12, 22, 0.5);
+  border-radius: 3px;
+}
+
+.menu-item {
+  font-family: "Inconsolata", monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #d9e9ff;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.menu-item:focus-visible {
+  outline: 1px dotted #f5f9ff;
+  outline-offset: 2px;
+}
+
+.menu-title {
+  margin-left: auto;
+  font-family: "Inconsolata", monospace;
+  font-size: 0.85rem;
+  color: rgba(222, 235, 255, 0.8);
+  text-transform: uppercase;
+}
+
+.windows {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+}
+
+.window {
+  background: linear-gradient(180deg, var(--window-bg-light), var(--window-bg-dark));
+  border: 2px solid var(--window-border-light);
+  border-right-color: var(--window-border-dark);
+  border-bottom-color: var(--window-border-dark);
+  box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.45);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.window-title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  font-family: "Inconsolata", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  background: linear-gradient(180deg, var(--header-grad-top), var(--header-grad-bottom));
+  color: var(--header-text);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.35);
+}
+
+.window-clock {
+  font-weight: 400;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.window-body {
+  padding: 12px;
+  background: repeating-linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.24),
+      rgba(255, 255, 255, 0.24) 2px,
+      rgba(255, 255, 255, 0.1) 2px,
+      rgba(255, 255, 255, 0.1) 4px
+    ),
+    rgba(232, 232, 232, 0.82);
+}
+
+.map-window {
+  flex: 1 1 640px;
+  min-width: 420px;
+}
+
+.map-window .window-body {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.map-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: var(--toolbar-bg);
+  padding: 10px;
+  border: 2px solid var(--toolbar-border);
+  box-shadow: inset 2px 2px 0 #f8f8f8, inset -2px -2px 0 #5a5a5a;
+}
+
+.toolbar-button {
+  font-family: "Inconsolata", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  padding: 6px 8px;
+  color: #1a1a1a;
+  background: linear-gradient(#e7e7e7, #c9c9c9);
+  border: 2px solid #ffffff;
+  border-bottom-color: #707070;
+  border-right-color: #707070;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.toolbar-button:focus-visible {
+  outline: 1px dotted #000;
+  outline-offset: 1px;
+}
+
+.toolbar-button:active {
+  border-top-color: #707070;
+  border-left-color: #707070;
+  border-bottom-color: #ffffff;
+  border-right-color: #ffffff;
+  background: linear-gradient(#bfbfbf, #d5d5d5);
+}
+
+.toolbar-button.active {
+  background: linear-gradient(#4471af, #325686);
+  border-color: #fffbea;
+  border-bottom-color: #1b2a43;
+  border-right-color: #1b2a43;
+  color: #f5f9ff;
+}
+
+.toolbar-divider {
+  height: 1px;
+  background: #6b6b6b;
+  margin: 6px 0;
+}
+
+#map-viewport {
+  position: relative;
+  flex: 1 1 520px;
+  aspect-ratio: 4 / 3;
+  border: 3px solid #0f1828;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.35);
+  background: #061020;
+  cursor: crosshair;
+  user-select: none;
+}
+
+#map-viewport.panning {
+  cursor: grabbing;
+}
+
+#scene-container,
+#scene-container canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+#scene-container canvas {
+  image-rendering: pixelated;
+  filter: saturate(0.95) contrast(1.05);
+}
+
+.mode-badge {
+  font-family: "Inconsolata", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  padding: 2px 10px;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  border-radius: 12px;
+  background: rgba(12, 22, 38, 0.6);
+  color: #fefefe;
+}
+
+.mode-badge.flash {
+  animation: badge-flash 0.4s ease-out;
+}
+
+@keyframes badge-flash {
+  from {
+    background: rgba(255, 211, 116, 0.8);
+    color: #1a1406;
+  }
+  to {
+    background: rgba(12, 22, 38, 0.6);
+    color: #fefefe;
+  }
+}
+
+.edit-window {
+  flex: 1 1 340px;
+  min-width: 320px;
+}
+
+.edit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.panel {
+  background: rgba(248, 248, 248, 0.9);
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  border-right-color: rgba(120, 120, 120, 0.7);
+  border-bottom-color: rgba(120, 120, 120, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(90, 90, 90, 0.25);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  font-family: "Inconsolata", monospace;
+  letter-spacing: 0.08em;
+  color: var(--accent-blue);
+}
+
+.operations .control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.control-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.control-group label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #222;
+  display: flex;
+  justify-content: space-between;
+  font-family: "Inconsolata", monospace;
+}
+
+.control-group input[type="range"] {
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  background: linear-gradient(90deg, #4a5568, #1f2a38);
+  border-radius: 2px;
+  border: 1px solid rgba(12, 20, 32, 0.8);
+}
+
+.control-group input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 14px;
+  background: linear-gradient(#fefefe, #bfbfbf);
+  border: 1px solid #2c2c2c;
+  box-shadow: inset 0 1px 0 #ffffff, inset -1px -1px 0 rgba(0, 0, 0, 0.4);
+}
+
+.control-group input[type="range"]::-moz-range-thumb {
+  width: 16px;
+  height: 14px;
+  background: linear-gradient(#fefefe, #bfbfbf);
+  border: 1px solid #2c2c2c;
+  box-shadow: inset 0 1px 0 #ffffff, inset -1px -1px 0 rgba(0, 0, 0, 0.4);
+}
+
+.control-group input[type="range"]::-moz-range-track {
+  background: transparent;
+}
+
+.control-group.compact {
+  flex: 1 1 120px;
+}
+
+.help-text {
+  margin: 0;
+  font-size: 0.7rem;
+  color: rgba(34, 34, 34, 0.8);
+}
+
+.control-row.buttons {
+  justify-content: space-between;
+}
+
+.control-row.buttons button,
+.toolbar-button,
+#toggle-sim,
+#step-sim,
+#reset-sim {
+  font-family: "Inconsolata", monospace;
+}
+
+.control-row.buttons button,
+.scenario-group select {
+  background: linear-gradient(#dcdcdc, #b9b9b9);
+  border: 2px solid #ffffff;
+  border-right-color: #5a5a5a;
+  border-bottom-color: #5a5a5a;
+  padding: 6px 10px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  letter-spacing: 0.06em;
+}
+
+.control-row.buttons button:active,
+.scenario-group select:focus {
+  border-top-color: #5a5a5a;
+  border-left-color: #5a5a5a;
+  border-right-color: #ffffff;
+  border-bottom-color: #ffffff;
+  outline: none;
+}
+
+.scenario-group select {
+  width: 100%;
+  font-family: "Inconsolata", monospace;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.metric,
+.metric-wide {
+  background: var(--metric-bg);
+  border: 1px solid var(--metric-border);
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: "Inconsolata", monospace;
+}
+
+.metric h3,
+.metric-wide h3 {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #2a2a2a;
+}
+
+.metric span,
+.metric-wide span {
+  font-size: 1rem;
+  color: #0b2447;
+}
+
+.metric-wide {
+  grid-column: 1 / -1;
+}
+
+.metric-wide.scorecard {
+  gap: 10px;
+}
+
+.scorecard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.scorecard-grade {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+
+#score-grade {
+  font-size: 1.35rem;
+  color: #123d63;
+  font-family: "Inconsolata", monospace;
+  font-weight: 700;
+}
+
+#score-delta {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: #5a5a5a;
+  text-transform: uppercase;
+  font-family: "Inconsolata", monospace;
+}
+
+#score-delta.positive {
+  color: #2f7f4f;
+}
+
+#score-delta.negative {
+  color: #8a1e1e;
+}
+
+#score-trend {
+  width: 100%;
+  height: auto;
+  display: block;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: rgba(10, 16, 28, 0.7);
+  image-rendering: pixelated;
+}
+
+#score-note {
+  margin: 0;
+  font-size: 0.7rem;
+  color: #1f2a3a;
+  font-family: "Inconsolata", monospace;
+}
+
+.panel-body {
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  padding: 10px;
+  min-height: 140px;
+  font-size: 0.8rem;
+}
+
+#unit-details h3 {
+  margin: 0 0 6px;
+  font-size: 0.9rem;
+  font-family: "Inconsolata", monospace;
+  color: #1f4b7a;
+}
+
+#unit-details p {
+  margin: 0;
+}
+
+.unit-status {
+  font-family: "Inconsolata", monospace;
+  font-size: 0.8rem;
+  margin-bottom: 8px;
+  color: #2c2c2c;
+}
+
+.unit-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 6px;
+}
+
+.unit-stat {
+  display: flex;
+  justify-content: space-between;
+  font-family: "Inconsolata", monospace;
+  font-size: 0.75rem;
+  padding: 4px 6px;
+  background: rgba(235, 235, 235, 0.8);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+#event-log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+  font-family: "Inconsolata", monospace;
+  font-size: 0.75rem;
+}
+
+.notes-list {
+  margin: 10px 0 0;
+  padding-left: 22px;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: #1f2a3a;
+  font-family: "Inconsolata", monospace;
+}
+
+.notes-list li {
+  margin-bottom: 4px;
+}
+
+#event-log li {
+  padding: 4px 6px;
+  background: rgba(216, 226, 237, 0.75);
+  border-left: 4px solid #3a5f82;
+}
+
+#event-log li.warning {
+  background: rgba(245, 228, 191, 0.78);
+  border-left-color: var(--log-warning);
+}
+
+#event-log li.danger {
+  background: rgba(244, 196, 196, 0.78);
+  border-left-color: var(--log-danger);
+}
+
+.about-window {
+  max-width: 720px;
+}
+
+.about-window .window-body {
+  background: rgba(246, 248, 252, 0.88);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: #1c2c40;
+}
+
+@media (max-width: 980px) {
+  body {
+    padding: 12px;
+  }
+
+  .windows {
+    flex-direction: column;
+  }
+
+  .map-window {
+    width: 100%;
+  }
+
+  #map-viewport {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .menu-bar {
+    flex-wrap: wrap;
+  }
+
+  .menu-title {
+    flex-basis: 100%;
+    margin-left: 0;
+    margin-top: 4px;
+  }
+
+  .map-toolbar {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .toolbar-divider {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add an operations scorecard with live grading, sparkline trend, and narrative feedback in the dashboard
- implement refinery unit gauges, alert sprites, and meta-tagged logs tied to enhanced reliability scoring
- introduce orthographic map panning/zooming controls with updated UI instructions and cursor treatments

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d0b7a18ffc8320b07058852bf99844